### PR TITLE
Add a Buidler task for typechain

### DIFF
--- a/buidler.config.ts
+++ b/buidler.config.ts
@@ -1,9 +1,38 @@
-import { usePlugin } from "@nomiclabs/buidler/config"
+import { task, usePlugin } from "@nomiclabs/buidler/config"
 import { BuidlerConfig } from "@nomiclabs/buidler/config"
+import { TASK_COMPILE } from "@nomiclabs/buidler/builtin-tasks/task-names";
+import { tsGenerator } from "ts-generator";
+import { TypeChain } from "typechain/dist/TypeChain";
 
 usePlugin("@nomiclabs/buidler-ethers")
 usePlugin("@nomiclabs/buidler-waffle")
 usePlugin("solidity-coverage")
+
+task(
+  "typechain",
+  "Generate contract typings with typechain"
+).setAction(async ({}, {config, run}) => {
+  await run(TASK_COMPILE);
+
+  console.log(
+    `Creating Typechain artifacts in ./build/typechain/...`
+  )
+
+  let cwd = process.cwd()
+  await tsGenerator(
+    { cwd },
+    new TypeChain({
+      cwd,
+      rawConfig: {
+        files: "./build/artifacts/*.json",
+        outDir: "./build/typechain/",
+        target: "ethers-v5",
+      },
+    })
+  )
+
+  console.log(`Successfully generated Typechain artifacts!`)
+})
 
 const config: BuidlerConfig = {
     defaultNetwork: "buidlerevm",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lint:fix:ts": "eslint --ext ts --fix ${npm_package_config_eslintPaths} && prettier --write test/*.ts",
     "lint:sol": "solium -d contracts/",
     "lint:fix:sol": "solium -d contracts/ --fix",
-    "build": "buidler compile && typechain --target ethers-v5 --outDir ./build/typechain './build/artifacts/*.json'",
+    "build": "buidler compile && buidler typechain",
     "test": "buidler test",
     "coverage": "buidler coverage --network coverage --temp ./build/artifacts"
   },


### PR DESCRIPTION
Use `buidler typechain` after a compile to get typings, or `npm run build` to get both. Easy peasy.

I'll probably have a few tooling-related PRs like this as I get `saddle-frontend` running.