### PR TITLE
Change values of fee parameters to realistic values

### DIFF
--- a/deployment/swap.ts
+++ b/deployment/swap.ts
@@ -17,8 +17,8 @@ import { ethers } from "hardhat"
 // Test Values
 const INITIAL_A_VALUE = 50
 const SWAP_FEE = 1e7
-const ADMIN_FEE = 5e10
-const WITHDRAW_FEE = 5e8
+const ADMIN_FEE = 0
+const WITHDRAW_FEE = 5e7
 const STABLECOIN_LP_TOKEN_NAME = "Stablecoin LP Token"
 const STABLECOIN_LP_TOKEN_SYMBOL = "SLPT"
 const BTC_LP_TOKEN_NAME = "BTC LP Token"


### PR DESCRIPTION
Change values of fee parameters to realistic values
```
const SWAP_FEE = 1e7
const ADMIN_FEE = 0
const WITHDRAW_FEE = 5e7
```

Swap fee is set to 0.1% of the trade output
Admin fee is set to 0% of the swap fee.
Withdraw fee is set to 0.5% of the withdrawal amount (decaying linearly over 4 weeks)