### PR TITLE
[L05] Update solidity version to 0.6.12 per Crytic's recommendation

### DIFF
--- a/contracts/Allowlist.sol
+++ b/contracts/Allowlist.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.7.6;
+pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
@@ -27,7 +27,7 @@ contract Allowlist is Ownable, IAllowlist {
      * @notice Creates this contract and sets PoolCap of 0x0 with uint256(0x54dd1e) for
      * crude checking whether an address holds this contract
      */
-    constructor() {
+    constructor() public {
         // This value will be used as a way of crude checking whether an address holds this Allowlist contract
         poolCaps[address(0x0)] = uint256(0x54dd1e);
         emit PoolCap(address(0x0), uint256(0x54dd1e));

--- a/contracts/CERC20.sol
+++ b/contracts/CERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.7.6;
+pragma solidity 0.6.12;
 import "./interfaces/ICERC20.sol";
 
 /**

--- a/contracts/LPToken.sol
+++ b/contracts/LPToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.7.6;
+pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20Burnable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
@@ -22,7 +22,7 @@ contract LPToken is ERC20Burnable, Ownable {
      * @param decimals_ number of decimals this token will be based on
      */
     constructor (string memory name_, string memory symbol_, uint8 decimals_
-    ) ERC20(name_, symbol_) {
+    ) public ERC20(name_, symbol_) {
         _setupDecimals(decimals_);
         swap = ISwap(_msgSender());
     }

--- a/contracts/MathUtils.sol
+++ b/contracts/MathUtils.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.7.6;
+pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 

--- a/contracts/OwnerPausable.sol
+++ b/contracts/OwnerPausable.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.7.6;
+pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/contracts/StakeableTokenWrapper.sol
+++ b/contracts/StakeableTokenWrapper.sol
@@ -1,6 +1,6 @@
 // Generalized and adapted from https://github.com/k06a/Unipool 🙇
 
-pragma solidity 0.7.6;
+pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
@@ -26,7 +26,7 @@ contract StakeableTokenWrapper {
      * @notice Creates a new StakeableTokenWrapper with given `_stakedToken` address
      * @param _stakedToken address of a token that will be used to stake
      */
-    constructor(IERC20 _stakedToken) {
+    constructor(IERC20 _stakedToken) public {
         stakedToken = _stakedToken;
     }
 

--- a/contracts/Swap.sol
+++ b/contracts/Swap.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.7.6;
+pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
@@ -85,7 +85,7 @@ contract Swap is OwnerPausable, ReentrancyGuard {
         IERC20[] memory _pooledTokens, uint256[] memory precisions,
         string memory lpTokenName, string memory lpTokenSymbol, uint256 _A,
         uint256 _fee, uint256 _adminFee, uint256 _withdrawFee, IAllowlist _allowlist
-    ) OwnerPausable() ReentrancyGuard() {
+    ) public OwnerPausable() ReentrancyGuard() {
         require(
             _pooledTokens.length > 1,
             "Pools must contain more than 1 token"

--- a/contracts/SwapUtils.sol
+++ b/contracts/SwapUtils.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.7.6;
+pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";

--- a/contracts/helper/GenericERC20.sol
+++ b/contracts/helper/GenericERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.7.6;
+pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
@@ -17,7 +17,7 @@ contract GenericERC20 is ERC20, Ownable {
      * @param decimals_ number of decimals this token will be based on
      */
     constructor (string memory name_, string memory symbol_, uint8 decimals_
-    ) ERC20(name_, symbol_) {
+    ) public ERC20(name_, symbol_) {
         _setupDecimals(decimals_);
     }
 

--- a/contracts/interfaces/IAllowlist.sol
+++ b/contracts/interfaces/IAllowlist.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.7.6;
+pragma solidity 0.6.12;
 
 interface IAllowlist {
     function getAllowedAmount(address poolAddress, address user) external view returns (uint256);

--- a/contracts/interfaces/ICERC20.sol
+++ b/contracts/interfaces/ICERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.7.6;
+pragma solidity 0.6.12;
 
 interface ICERC20 {
     function mint(uint256) external returns (uint256);

--- a/contracts/interfaces/ISwap.sol
+++ b/contracts/interfaces/ISwap.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.7.6;
+pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -19,7 +19,7 @@ const config: HardhatUserConfig = {
     cache: "./build/cache",
   },
   solidity: {
-    version: "0.7.6",
+    version: "0.6.12",
     settings: {
       optimizer: {
         enabled: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -779,9 +779,9 @@
       }
     },
     "@openzeppelin/contracts": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-2.5.1.tgz",
-      "integrity": "sha512-qIy6tLx8rtybEsIOAlrM4J/85s2q2nPkDqj/Rx46VakBZ0LwtFhXIVub96LXHczQX0vaqmAueDqNPXtbSXSaYQ=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.3.0.tgz",
+      "integrity": "sha512-AemZEsQYtUp1WRkcmZm1div5ORfTpLquLaziCIrSagjxyKdmObxuaY1yjQ5SHFMctR8rLwp706NXTbiIRJg7pw=="
     },
     "@resolver-engine/core": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@eth-optimism/smock": "^0.1.1-alpha.0",
-    "@openzeppelin/contracts": "solc-0.7",
+    "@openzeppelin/contracts": "3.3.0",
     "hardhat-typechain": "^0.3.3",
     "synthetix": "2.34.2"
   },


### PR DESCRIPTION
Solidity 0.7 fixes various issues, two notable bugs are the below ones.
https://blog.soliditylang.org/2020/10/07/solidity-dynamic-array-cleanup-bug/
https://blog.soliditylang.org/2020/10/19/empty-byte-array-copy-bug/

However as our codebase does not rely on resizing an array without inserting values, we are not exposed to the bugs currently. List of known bugs and fixes can be found here 
https://docs.soliditylang.org/en/v0.7.6/bugs.html

We will follow crytic's development guidelines and move to `0.6.12`
https://github.com/crytic/building-secure-contracts/blob/master/development-guidelines/guidelines.md#solidity