### PR TITLE
[N06] Writing custom Pausable and ERC20Mintable contracts

### DIFF
--- a/contracts/OwnerPausable.sol
+++ b/contracts/OwnerPausable.sol
@@ -1,6 +1,8 @@
 pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/Pausable.sol";
+
 
 /**
  * @title OwnerPausable
@@ -8,43 +10,19 @@ import "@openzeppelin/contracts/access/Ownable.sol";
  * contract without a delay.
  * @dev Only methods using the provided modifiers will be paused.
  */
-contract OwnerPausable is Ownable {
-
-    event Paused();
-    event Unpaused();
-
-    bool private paused = false;
+contract OwnerPausable is Ownable, Pausable {
 
     /**
      * @notice Pause the contract. Revert if already paused.
      */
-    function pause() external onlyOwner onlyUnpaused {
-        paused = true;
-        emit Paused();
+    function pause() external onlyOwner {
+        Pausable._pause();
     }
 
     /**
      * @notice Unpause the contract. Revert if already unpaused.
      */
-    function unpause() external onlyOwner onlyPaused {
-        paused = false;
-        emit Unpaused();
-    }
-
-
-    /**
-     * @notice Revert if the contract is paused.
-     */
-    modifier onlyUnpaused() {
-        require(!paused, "Method can only be called when unpaused");
-        _;
-    }
-
-    /**
-     * @notice Revert if the contract is unpaused.
-     */
-    modifier onlyPaused() {
-        require(paused, "Method can only be called when paused");
-        _;
+    function unpause() external onlyOwner {
+        Pausable._unpause();
     }
 }

--- a/contracts/Swap.sol
+++ b/contracts/Swap.sol
@@ -309,7 +309,7 @@ contract Swap is OwnerPausable, ReentrancyGuard {
      */
     function swap(
         uint8 tokenIndexFrom, uint8 tokenIndexTo, uint256 dx, uint256 minDy, uint256 deadline
-    ) external nonReentrant onlyUnpaused deadlineCheck(deadline) {
+    ) external nonReentrant whenNotPaused deadlineCheck(deadline) {
         return swapStorage.swap(tokenIndexFrom, tokenIndexTo, dx, minDy);
     }
 
@@ -321,7 +321,7 @@ contract Swap is OwnerPausable, ReentrancyGuard {
      * @param deadline latest timestamp to accept this transaction
      */
     function addLiquidity(uint256[] calldata amounts, uint256 minToMint, uint256 deadline)
-        external nonReentrant onlyUnpaused deadlineCheck(deadline) {
+        external nonReentrant whenNotPaused deadlineCheck(deadline) {
         swapStorage.addLiquidity(amounts, minToMint);
 
         if (isGuarded) {
@@ -362,7 +362,7 @@ contract Swap is OwnerPausable, ReentrancyGuard {
      */
     function removeLiquidityOneToken(
         uint256 tokenAmount, uint8 tokenIndex, uint256 minAmount, uint256 deadline
-    ) external nonReentrant onlyUnpaused deadlineCheck(deadline) {
+    ) external nonReentrant whenNotPaused deadlineCheck(deadline) {
         return swapStorage.removeLiquidityOneToken(tokenAmount, tokenIndex, minAmount);
     }
 
@@ -377,7 +377,7 @@ contract Swap is OwnerPausable, ReentrancyGuard {
      */
     function removeLiquidityImbalance(
         uint256[] calldata amounts, uint256 maxBurnAmount, uint256 deadline
-    ) external nonReentrant onlyUnpaused deadlineCheck(deadline) {
+    ) external nonReentrant whenNotPaused deadlineCheck(deadline) {
         return swapStorage.removeLiquidityImbalance(amounts, maxBurnAmount);
     }
 


### PR DESCRIPTION
This commit changes OwnerPausable such that it inherits pausing functionalities from Pausable from OpenZeppelin.

As ERC20Mintable contract no longer exists in OpenZeppelin v3.0+, we left LPToken.sol as is.