### PR TITLE
Use shorter reason strings in require/revert statements

### DIFF
--- a/contracts/Swap.sol
+++ b/contracts/Swap.sol
@@ -128,17 +128,11 @@ contract Swap is OwnerPausable, ReentrancyGuard {
         IAllowlist _allowlist
     ) public OwnerPausable() ReentrancyGuard() {
         // Check _pooledTokens and precisions parameter
-        require(
-            _pooledTokens.length > 1,
-            "Pools must contain more than 1 token"
-        );
-        require(
-            _pooledTokens.length <= 32,
-            "Pools with over 32 tokens aren't supported"
-        );
+        require(_pooledTokens.length > 1, "_pooledTokens.length <= 1");
+        require(_pooledTokens.length <= 32, "_pooledTokens.length > 32");
         require(
             _pooledTokens.length == decimals.length,
-            "Each pooled token needs a specified decimals"
+            "_pooledTokens decimals mismatch"
         );
 
         uint256[] memory precisionMultipliers = new uint256[](decimals.length);
@@ -149,7 +143,7 @@ contract Swap is OwnerPausable, ReentrancyGuard {
                 require(
                     tokenIndexes[address(_pooledTokens[i])] == 0 &&
                         _pooledTokens[0] != _pooledTokens[i],
-                    "Pools cannot have duplicate tokens"
+                    "Duplicate tokens"
                 );
             }
             require(
@@ -158,7 +152,7 @@ contract Swap is OwnerPausable, ReentrancyGuard {
             );
             require(
                 decimals[i] <= SwapUtils.POOL_PRECISION_DECIMALS,
-                "Token decimals can't be higher than the pool's precision decimals"
+                "Token decimals exceeds max"
             );
             precisionMultipliers[i] =
                 10 **
@@ -539,7 +533,7 @@ contract Swap is OwnerPausable, ReentrancyGuard {
     {
         require(
             msg.sender == address(swapStorage.lpToken),
-            "Only token transfers can update withdraw fee"
+            "Only callable by pool token"
         );
         swapStorage.updateUserWithdrawFee(recipient, transferAmount);
     }

--- a/contracts/SwapUtils.sol
+++ b/contracts/SwapUtils.sol
@@ -289,10 +289,7 @@ library SwapUtils {
         v.d0 = getD(xp, v.preciseA);
         v.d1 = v.d0.sub(tokenAmount.mul(v.d0).div(self.lpToken.totalSupply()));
 
-        require(
-            tokenAmount <= xp[tokenIndex],
-            "Cannot withdraw more than available"
-        );
+        require(tokenAmount <= xp[tokenIndex], "Withdraw exceeds available");
 
         v.newY = getYD(v.preciseA, tokenIndex, xp, v.d1);
 
@@ -459,7 +456,7 @@ library SwapUtils {
         uint256 numTokens = balances.length;
         require(
             numTokens == precisionMultipliers.length,
-            "Balances must map to token precision multipliers"
+            "Balances must match multipliers"
         );
         uint256[] memory xp = new uint256[](numTokens);
         for (uint256 i = 0; i < numTokens; i++) {
@@ -868,7 +865,7 @@ library SwapUtils {
     ) external returns (uint256) {
         require(
             amounts.length == self.pooledTokens.length,
-            "Amounts must map to pooled tokens"
+            "Amounts must match pooled tokens"
         );
 
         uint256[] memory fees = new uint256[](self.pooledTokens.length);
@@ -884,7 +881,7 @@ library SwapUtils {
         for (uint256 i = 0; i < self.pooledTokens.length; i++) {
             require(
                 self.lpToken.totalSupply() != 0 || amounts[i] > 0,
-                "If token supply is zero, must supply all tokens in pool"
+                "Must supply all tokens in pool"
             );
 
             // Transfer tokens first to see if a fee was charged on transfer
@@ -909,7 +906,7 @@ library SwapUtils {
         // invariant after change
         v.preciseA = _getAPrecise(self);
         v.d1 = getD(_xp(self, newBalances), v.preciseA);
-        require(v.d1 > v.d0, "D should increase after additional liquidity");
+        require(v.d1 > v.d0, "D should increase");
 
         // updated to reflect fees and calculate the user's LP tokens
         v.d2 = v.d1;
@@ -938,7 +935,7 @@ library SwapUtils {
             toMint = v.d2.sub(v.d0).mul(self.lpToken.totalSupply()).div(v.d0);
         }
 
-        require(toMint >= minToMint, "Couldn't mint min requested LP tokens");
+        require(toMint >= minToMint, "Couldn't mint min requested");
 
         // mint the user's LP tokens
         self.lpToken.mint(msg.sender, toMint, merkleProof);
@@ -1017,17 +1014,14 @@ library SwapUtils {
         require(amount <= self.lpToken.balanceOf(msg.sender), ">LP.balanceOf");
         require(
             minAmounts.length == self.pooledTokens.length,
-            "Min amounts should correspond to pooled tokens"
+            "minAmounts must match poolTokens"
         );
 
         uint256[] memory amounts =
             _calculateRemoveLiquidity(self, msg.sender, amount);
 
         for (uint256 i = 0; i < amounts.length; i++) {
-            require(
-                amounts[i] >= minAmounts[i],
-                "Resulted in fewer tokens than expected"
-            );
+            require(amounts[i] >= minAmounts[i], "amounts[i] < minAmounts[i]");
             self.balances[i] = self.balances[i].sub(amounts[i]);
             self.pooledTokens[i].safeTransfer(msg.sender, amounts[i]);
         }
@@ -1071,7 +1065,7 @@ library SwapUtils {
             tokenIndex
         );
 
-        require(dy >= minAmount, "The min amount of tokens wasn't met");
+        require(dy >= minAmount, "dy < minAmount");
 
         self.balances[tokenIndex] = self.balances[tokenIndex].sub(
             dy.add(dyFee.mul(self.adminFee).div(FEE_DENOMINATOR))
@@ -1107,7 +1101,7 @@ library SwapUtils {
     ) public returns (uint256) {
         require(
             amounts.length == self.pooledTokens.length,
-            "Amounts should correspond to pooled tokens"
+            "Amounts should match pool tokens"
         );
         require(
             maxBurnAmount <= self.lpToken.balanceOf(msg.sender) &&
@@ -1152,10 +1146,7 @@ library SwapUtils {
             FEE_DENOMINATOR.sub(calculateCurrentWithdrawFee(self, msg.sender))
         );
 
-        require(
-            tokenAmount <= maxBurnAmount,
-            "More expensive than the max burn amount"
-        );
+        require(tokenAmount <= maxBurnAmount, "tokenAmount > maxBurnAmount");
 
         self.lpToken.burnFrom(msg.sender, tokenAmount);
 
@@ -1245,7 +1236,7 @@ library SwapUtils {
     ) external {
         require(
             block.timestamp >= self.initialATime.add(1 days),
-            "New ramp cannot be started until 1 day has passed"
+            "Wait 1 day before starting ramp"
         );
         require(
             futureTime_ >= block.timestamp.add(MIN_RAMP_TIME),
@@ -1253,7 +1244,7 @@ library SwapUtils {
         );
         require(
             futureA_ > 0 && futureA_ < MAX_A,
-            "futureA_ must be between 0 and MAX_A"
+            "futureA_ must be > 0 and < MAX_A"
         );
 
         uint256 initialAPrecise = _getAPrecise(self);

--- a/test/swapConstructor.ts
+++ b/test/swapConstructor.ts
@@ -69,7 +69,7 @@ describe("Swap", () => {
   })
 
   describe("swapStorage#constructor", () => {
-    it("Reverts with 'Pools must contain more than 1 token'", async () => {
+    it("Reverts with '_pooledTokens.length <= 1'", async () => {
       await expect(
         deployContractWithLibraries(
           owner,
@@ -87,10 +87,10 @@ describe("Swap", () => {
             allowlist.address,
           ],
         ),
-      ).to.be.revertedWith("Pools must contain more than 1 token")
+      ).to.be.revertedWith("_pooledTokens.length <= 1")
     })
 
-    it("Reverts with 'Pools with over 32 tokens aren't supported'", async () => {
+    it("Reverts with '_pooledTokens.length > 32'", async () => {
       await expect(
         deployContractWithLibraries(
           owner,
@@ -108,10 +108,10 @@ describe("Swap", () => {
             allowlist.address,
           ],
         ),
-      ).to.be.revertedWith("Pools with over 32 tokens aren't supported")
+      ).to.be.revertedWith("_pooledTokens.length > 32")
     })
 
-    it("Reverts with 'Each pooled token needs a specified precision'", async () => {
+    it("Reverts with '_pooledTokens decimals mismatch'", async () => {
       await expect(
         deployContractWithLibraries(
           owner,
@@ -129,10 +129,10 @@ describe("Swap", () => {
             allowlist.address,
           ],
         ),
-      ).to.be.revertedWith("Each pooled token needs a specified decimals")
+      ).to.be.revertedWith("_pooledTokens decimals mismatch")
     })
 
-    it("Reverts with 'Pools cannot have duplicate tokens'", async () => {
+    it("Reverts with 'Duplicate tokens'", async () => {
       await expect(
         deployContractWithLibraries(
           owner,
@@ -150,7 +150,7 @@ describe("Swap", () => {
             allowlist.address,
           ],
         ),
-      ).to.be.revertedWith("Pools cannot have duplicate tokens")
+      ).to.be.revertedWith("Duplicate tokens")
     })
 
     it("Reverts with 'The 0 address isn't an ERC-20'", async () => {
@@ -174,7 +174,7 @@ describe("Swap", () => {
       ).to.be.revertedWith("The 0 address isn't an ERC-20")
     })
 
-    it("Reverts with 'Token decimals can't be higher than the pool's precision decimals'", async () => {
+    it("Reverts with 'Token decimals exceeds max'", async () => {
       await expect(
         deployContractWithLibraries(
           owner,
@@ -192,9 +192,7 @@ describe("Swap", () => {
             allowlist.address,
           ],
         ),
-      ).to.be.revertedWith(
-        "Token decimals can't be higher than the pool's precision decimals",
-      )
+      ).to.be.revertedWith("Token decimals exceeds max")
     })
 
     it("Reverts with '_a exceeds maximum'", async () => {


### PR DESCRIPTION
Closes #230

They should be <=32 characters to save gas.