### PR TITLE
Add deployment scripts for mirroring and forking mainnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ $ npm run coverage
 
 ```bash
 $ npx hardhat node
-$ npx hardhat run --network localhost deployment/swap.ts
+$ npx hardhat run --network localhost deployment/hardhat/swap.ts
 ```
+
+`deployment/hardhat/swap-forkMainnet.ts` is also available for forking the mainnet contracts into the hardhat network.
 
 You can connect to this RPC server via `localhost:8545`.
 

--- a/deployment/hardhat/swap-forkMainnet.ts
+++ b/deployment/hardhat/swap-forkMainnet.ts
@@ -1,0 +1,82 @@
+import { GenericERC20 } from "../../build/typechain/GenericErc20"
+import GenericERC20Artifact from "../../build/artifacts/contracts/helper/GenericERC20.sol/GenericERC20.json"
+import { Swap } from "../../build/typechain/Swap"
+import SwapArtifact from "../../build/artifacts/contracts/Swap.sol/Swap.json"
+import { LPToken } from "../../build/typechain/LpToken"
+import LPTokenArtifact from "../../build/artifacts/contracts/LPToken.sol/LPToken.json"
+import { ethers, network } from "hardhat"
+import dotenv from "dotenv"
+
+// Mainnet Addresses
+const SADDLE_BTC_POOL = "0x4f6A43Ad7cba042606dECaCA730d4CE0A57ac62e"
+const SADDLE_BTC_LP_TOKEN = "0xC28DF698475dEC994BE00C9C9D8658A548e6304F"
+
+const TBTC = "0x8dAEBADE922dF735c38C80C7eBD708Af50815fAa"
+const WBTC = "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
+const RENBTC = "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d"
+const SBTC = "0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6"
+
+const BLOCK_NUMBER = 11772093
+
+dotenv.config()
+
+async function forkMainnet(): Promise<void> {
+  await network.provider.request({
+    method: "hardhat_reset",
+    params: [
+      {
+        forking: {
+          jsonRpcUrl: process.env.ALCHEMY_API,
+          blockNumber: BLOCK_NUMBER,
+        },
+      },
+    ],
+  })
+
+  const tbtcToken = (await ethers.getContractAt(
+    GenericERC20Artifact.abi,
+    TBTC,
+  )) as GenericERC20
+
+  const wbtcToken = (await ethers.getContractAt(
+    GenericERC20Artifact.abi,
+    WBTC,
+  )) as GenericERC20
+
+  const renbtcToken = (await ethers.getContractAt(
+    GenericERC20Artifact.abi,
+    RENBTC,
+  )) as GenericERC20
+
+  const sbtcToken = (await ethers.getContractAt(
+    GenericERC20Artifact.abi,
+    SBTC,
+  )) as GenericERC20
+
+  const btcTokens = [tbtcToken, wbtcToken, renbtcToken, sbtcToken]
+
+  console.table(
+    await Promise.all(
+      btcTokens.map(async (t) => [await t.symbol(), t.address]),
+    ),
+  )
+
+  const btcSwap = (await ethers.getContractAt(
+    SwapArtifact.abi,
+    SADDLE_BTC_POOL,
+  )) as Swap
+
+  const btcLpToken = (await ethers.getContractAt(
+    LPTokenArtifact.abi,
+    SADDLE_BTC_LP_TOKEN,
+  )) as LPToken
+
+  console.log(`Tokenized BTC swap address: ${btcSwap.address}`)
+  console.log(`Tokenized BTC swap token address: ${btcLpToken.address}`)
+}
+
+forkMainnet().then(() => {
+  console.log(
+    `Successfully forked mainnet @ block ${BLOCK_NUMBER} to local hardhat network...`,
+  )
+})

--- a/deployment/hardhat/swap.ts
+++ b/deployment/hardhat/swap.ts
@@ -1,0 +1,226 @@
+import { Allowlist } from "../../build/typechain/Allowlist"
+import AllowlistArtifact from "../../build/artifacts/contracts/Allowlist.sol/Allowlist.json"
+import { BigNumber } from "@ethersproject/bignumber"
+import { GenericERC20 } from "../../build/typechain/GenericErc20"
+import GenericERC20Artifact from "../../build/artifacts/contracts/helper/GenericERC20.sol/GenericERC20.json"
+import { MathUtils } from "../../build/typechain/MathUtils"
+import MathUtilsArtifact from "../../build/artifacts/contracts/MathUtils.sol/MathUtils.json"
+import { Swap } from "../../build/typechain/Swap"
+import SwapArtifact from "../../build/artifacts/contracts/Swap.sol/Swap.json"
+import { SwapUtils } from "../../build/typechain/SwapUtils"
+import SwapUtilsArtifact from "../../build/artifacts/contracts/SwapUtils.sol/SwapUtils.json"
+import { Wallet } from "ethers"
+import { deployContract } from "ethereum-waffle"
+import { asyncForEach, deployContractWithLibraries } from "../../test/testUtils"
+import { ethers } from "hardhat"
+import merkleTreeData from "../../test/exampleMerkleTree.json"
+
+// Test Values
+const INITIAL_A_VALUE = 50
+const SWAP_FEE = 1e7
+const ADMIN_FEE = 0
+const WITHDRAW_FEE = 5e7
+const STABLECOIN_LP_TOKEN_NAME = "Stablecoin LP Token"
+const STABLECOIN_LP_TOKEN_SYMBOL = "SLPT"
+const BTC_LP_TOKEN_NAME = "BTC LP Token"
+const BTC_LP_TOKEN_SYMBOL = "BLPT"
+
+async function deploySwap(): Promise<void> {
+  const signers = await ethers.getSigners()
+
+  const owner = signers[0]
+  const user1 = signers[1]
+  const user2 = signers[2]
+
+  const ownerAddress = await owner.getAddress()
+  const user1Address = await user1.getAddress()
+  const user2Address = await user2.getAddress()
+  const addresses = [ownerAddress, user1Address, user2Address]
+
+  // Deploy dummy tokens
+  const daiToken = (await deployContract(
+    (owner as unknown) as Wallet,
+    GenericERC20Artifact,
+    ["Dai", "DAI", "18"],
+  )) as GenericERC20
+  await daiToken.deployed()
+
+  const usdcToken = (await deployContract(
+    (owner as unknown) as Wallet,
+    GenericERC20Artifact,
+    ["USDC Coin", "USDC", "6"],
+  )) as GenericERC20
+  await usdcToken.deployed()
+
+  const usdtToken = (await deployContract(
+    (owner as unknown) as Wallet,
+    GenericERC20Artifact,
+    ["Tether", "USDT", "6"],
+  )) as GenericERC20
+  await usdtToken.deployed()
+
+  const susdToken = (await deployContract(
+    (owner as unknown) as Wallet,
+    GenericERC20Artifact,
+    ["sUSD", "SUSD", "18"],
+  )) as GenericERC20
+  await susdToken.deployed()
+
+  const tbtcToken = (await deployContract(
+    (owner as unknown) as Wallet,
+    GenericERC20Artifact,
+    ["tBTC", "TBTC", "18"],
+  )) as GenericERC20
+  await tbtcToken.deployed()
+
+  const wbtcToken = (await deployContract(
+    (owner as unknown) as Wallet,
+    GenericERC20Artifact,
+    ["Wrapped Bitcoin", "WBTC", "8"],
+  )) as GenericERC20
+  await wbtcToken.deployed()
+
+  const renbtcToken = (await deployContract(
+    (owner as unknown) as Wallet,
+    GenericERC20Artifact,
+    ["renBTC", "RENBTC", "8"],
+  )) as GenericERC20
+  await renbtcToken.deployed()
+
+  const sbtcToken = (await deployContract(
+    (owner as unknown) as Wallet,
+    GenericERC20Artifact,
+    ["sBTC", "SBTC", "18"],
+  )) as GenericERC20
+  await sbtcToken.deployed()
+
+  const tokens = [
+    daiToken,
+    usdcToken,
+    usdtToken,
+    susdToken,
+    tbtcToken,
+    wbtcToken,
+    renbtcToken,
+    sbtcToken,
+  ]
+
+  console.table(
+    await Promise.all(tokens.map(async (t) => [await t.symbol(), t.address])),
+  )
+
+  await asyncForEach(addresses, async (address) => {
+    await asyncForEach(tokens, async (token) => {
+      const decimals = await token.decimals()
+      // Stringifying numbers over 1e20 breaks BigNumber, so get creative
+      const amount = "1" + new Array(decimals + 5).fill(0).join("")
+      await token.mint(address, amount)
+    })
+  })
+
+  // Deploy Allowlist
+  const allowlist = (await deployContract(
+    (signers[0] as unknown) as Wallet,
+    AllowlistArtifact,
+    [merkleTreeData.merkleRoot],
+  )) as Allowlist
+  await allowlist.deployed()
+
+  // Deploy MathUtils
+  const mathUtils = (await deployContract(
+    (signers[0] as unknown) as Wallet,
+    MathUtilsArtifact,
+  )) as MathUtils
+  await mathUtils.deployed()
+
+  // Deploy SwapUtils with MathUtils library
+  const swapUtils = (await deployContractWithLibraries(
+    owner,
+    SwapUtilsArtifact,
+    {
+      MathUtils: mathUtils.address,
+    },
+  )) as SwapUtils
+  await swapUtils.deployed()
+
+  // Deploy Swap with SwapUtils library
+  const stablecoinSwap = (await deployContractWithLibraries(
+    owner,
+    SwapArtifact,
+    { SwapUtils: swapUtils.address },
+    [
+      [
+        daiToken.address,
+        usdcToken.address,
+        usdtToken.address,
+        susdToken.address,
+      ],
+      [18, 6, 6, 18],
+      STABLECOIN_LP_TOKEN_NAME,
+      STABLECOIN_LP_TOKEN_SYMBOL,
+      INITIAL_A_VALUE,
+      SWAP_FEE,
+      ADMIN_FEE,
+      WITHDRAW_FEE,
+      allowlist.address,
+    ],
+  )) as Swap
+  await stablecoinSwap.deployed()
+
+  const btcSwap = (await deployContractWithLibraries(
+    owner,
+    SwapArtifact,
+    { SwapUtils: swapUtils.address },
+    [
+      [
+        tbtcToken.address,
+        wbtcToken.address,
+        renbtcToken.address,
+        sbtcToken.address,
+      ],
+      [18, 8, 8, 18],
+      BTC_LP_TOKEN_NAME,
+      BTC_LP_TOKEN_SYMBOL,
+      INITIAL_A_VALUE,
+      SWAP_FEE,
+      ADMIN_FEE,
+      WITHDRAW_FEE,
+      allowlist.address,
+    ],
+  )) as Swap
+  await btcSwap.deployed()
+
+  // update dev limits for stableSwap
+  await allowlist.setPoolCap(
+    stablecoinSwap.address,
+    BigNumber.from(10).pow(18).mul(1000),
+  )
+  await allowlist.setPoolAccountLimit(
+    stablecoinSwap.address,
+    BigNumber.from(10).pow(18).mul(1000),
+  )
+
+  // update dev limits for btcSwap
+  await allowlist.setPoolCap(
+    btcSwap.address,
+    BigNumber.from(10).pow(18).mul(1000),
+  )
+  await allowlist.setPoolAccountLimit(
+    btcSwap.address,
+    BigNumber.from(10).pow(18).mul(1000),
+  )
+
+  await stablecoinSwap.deployed()
+  const stablecoinLpToken = (await stablecoinSwap.swapStorage()).lpToken
+  await btcSwap.deployed()
+  const btcLpToken = (await btcSwap.swapStorage()).lpToken
+
+  console.log(`Stablecoin swap address: ${stablecoinSwap.address}`)
+  console.log(`Stablecoin swap token address: ${stablecoinLpToken}`)
+  console.log(`Tokenized BTC swap address: ${btcSwap.address}`)
+  console.log(`Tokenized BTC swap token address: ${btcLpToken}`)
+}
+
+deploySwap().then(() => {
+  console.log("Successfully deployed contracts locally...")
+})

--- a/deployment/onchain/swap-mainnet.ts
+++ b/deployment/onchain/swap-mainnet.ts
@@ -1,14 +1,14 @@
-import { Allowlist } from "../build/typechain/Allowlist"
-import AllowlistArtifact from "../build/artifacts/contracts/Allowlist.sol/Allowlist.json"
+import { Allowlist } from "../../build/typechain/Allowlist"
+import AllowlistArtifact from "../../build/artifacts/contracts/Allowlist.sol/Allowlist.json"
 import { BigNumber } from "@ethersproject/bignumber"
-import { MathUtils } from "../build/typechain/MathUtils"
-import MathUtilsArtifact from "../build/artifacts/contracts/MathUtils.sol/MathUtils.json"
-import { Swap } from "../build/typechain/Swap"
-import SwapArtifact from "../build/artifacts/contracts/Swap.sol/Swap.json"
-import { SwapUtils } from "../build/typechain/SwapUtils"
-import SwapUtilsArtifact from "../build/artifacts/contracts/SwapUtils.sol/SwapUtils.json"
+import { MathUtils } from "../../build/typechain/MathUtils"
+import MathUtilsArtifact from "../../build/artifacts/contracts/MathUtils.sol/MathUtils.json"
+import { Swap } from "../../build/typechain/Swap"
+import SwapArtifact from "../../build/artifacts/contracts/Swap.sol/Swap.json"
+import { SwapUtils } from "../../build/typechain/SwapUtils"
+import SwapUtilsArtifact from "../../build/artifacts/contracts/SwapUtils.sol/SwapUtils.json"
 import { deployContract } from "ethereum-waffle"
-import { deployContractWithLibraries } from "../test/testUtils"
+import { deployContractWithLibraries } from "../../test/testUtils"
 import { ethers } from "hardhat"
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address"
 
@@ -32,7 +32,7 @@ const BTC_LP_TOKEN_SYMBOL = "saddleTWRenSBTC"
 const MULTISIG_ADDRESS = "0x3F8E527aF4e0c6e763e8f368AC679c44C45626aE"
 
 // To run this script and deploy the contracts on the mainnet:
-//    npx hardhat run deployment/swap-onchain.ts --network mainnet
+//    npx hardhat run deployment/onchain/swap-mainnet.ts --network mainnet
 //
 // To verify the source code on etherscan:
 //    npx hardhat verify --network mainnet DEPLOYED_CONTRACT_ADDRESS [arg0, arg1, ...]


### PR DESCRIPTION
Mirroring script will use realistic values when deploying Swap and Allowlist. Amount of tokens for each test account is also limited.

Forking script will fork the mainnet. This will run on chainId 31337 but have the same contract addresses as the mainnet.