### PR TITLE
Disable the pool guard in the local deployment script

### DIFF
--- a/deployment/hardhat/swap.ts
+++ b/deployment/hardhat/swap.ts
@@ -1,5 +1,3 @@
-import { asyncForEach, deployContractWithLibraries } from "../../test/testUtils"
-
 import { Allowlist } from "../../build/typechain/Allowlist"
 import AllowlistArtifact from "../../build/artifacts/contracts/Allowlist.sol/Allowlist.json"
 import { BigNumber } from "@ethersproject/bignumber"
@@ -13,6 +11,7 @@ import { SwapUtils } from "../../build/typechain/SwapUtils"
 import SwapUtilsArtifact from "../../build/artifacts/contracts/SwapUtils.sol/SwapUtils.json"
 import { Wallet } from "ethers"
 import { deployContract } from "ethereum-waffle"
+import { asyncForEach, deployContractWithLibraries } from "../../test/testUtils"
 import { ethers } from "hardhat"
 import merkleTreeData from "../../test/exampleMerkleTree.json"
 

--- a/deployment/hardhat/swap.ts
+++ b/deployment/hardhat/swap.ts
@@ -1,3 +1,5 @@
+import { asyncForEach, deployContractWithLibraries } from "../../test/testUtils"
+
 import { Allowlist } from "../../build/typechain/Allowlist"
 import AllowlistArtifact from "../../build/artifacts/contracts/Allowlist.sol/Allowlist.json"
 import { BigNumber } from "@ethersproject/bignumber"
@@ -11,7 +13,6 @@ import { SwapUtils } from "../../build/typechain/SwapUtils"
 import SwapUtilsArtifact from "../../build/artifacts/contracts/SwapUtils.sol/SwapUtils.json"
 import { Wallet } from "ethers"
 import { deployContract } from "ethereum-waffle"
-import { asyncForEach, deployContractWithLibraries } from "../../test/testUtils"
 import { ethers } from "hardhat"
 import merkleTreeData from "../../test/exampleMerkleTree.json"
 
@@ -166,6 +167,7 @@ async function deploySwap(): Promise<void> {
     ],
   )) as Swap
   await stablecoinSwap.deployed()
+  await stablecoinSwap.disableGuard()
 
   const btcSwap = (await deployContractWithLibraries(
     owner,
@@ -189,6 +191,7 @@ async function deploySwap(): Promise<void> {
     ],
   )) as Swap
   await btcSwap.deployed()
+  await btcSwap.disableGuard()
 
   // update dev limits for stableSwap
   await allowlist.setPoolCap(


### PR DESCRIPTION
Fixes local frontend development now that the pool guard has been removed in prod.