### PR TITLE
Add missing await to fix coverage

### DIFF
--- a/test/swap.ts
+++ b/test/swap.ts
@@ -442,7 +442,7 @@ describe("Swap", async () => {
         .mul(999)
         .div(1000)
 
-      expect(
+      await expect(
         swap
           .connect(user1)
           .addLiquidity(


### PR DESCRIPTION
This fixes a subtle bug that was causing `npm run coverage` to fail intermittently:

![Screen Shot 2021-03-02 at 11 27 28 AM](https://user-images.githubusercontent.com/972382/109703425-4fb52500-7b4a-11eb-8275-8994767fd3a6.png)

eg https://github.com/saddle-finance/saddle-contract/pull/278/checks?check_run_id=2015972238