### PR TITLE
Reorder the transactions in deployment script to preserve the nonces

### DIFF
--- a/deployment/hardhat/swap-mirrorMainnet.ts
+++ b/deployment/hardhat/swap-mirrorMainnet.ts
@@ -192,6 +192,10 @@ async function deploySwap(): Promise<void> {
   )) as Swap
   await btcSwap.deployed()
 
+  // Disable Guard
+  await btcSwap.disableGuard()
+  await stablecoinSwap.disableGuard()
+
   // update dev limits for stableSwap
   await allowlist.setPoolCap(
     stablecoinSwap.address,

--- a/deployment/hardhat/swap.ts
+++ b/deployment/hardhat/swap.ts
@@ -166,7 +166,6 @@ async function deploySwap(): Promise<void> {
     ],
   )) as Swap
   await stablecoinSwap.deployed()
-  await stablecoinSwap.disableGuard()
 
   const btcSwap = (await deployContractWithLibraries(
     owner,
@@ -190,7 +189,10 @@ async function deploySwap(): Promise<void> {
     ],
   )) as Swap
   await btcSwap.deployed()
+
+  // Disable Guard
   await btcSwap.disableGuard()
+  await stablecoinSwap.disableGuard()
 
   // update dev limits for stableSwap
   await allowlist.setPoolCap(
@@ -212,9 +214,7 @@ async function deploySwap(): Promise<void> {
     BigNumber.from(10).pow(18).mul(1000),
   )
 
-  await stablecoinSwap.deployed()
   const stablecoinLpToken = (await stablecoinSwap.swapStorage()).lpToken
-  await btcSwap.deployed()
   const btcLpToken = (await btcSwap.swapStorage()).lpToken
 
   console.log(`Stablecoin swap address: ${stablecoinSwap.address}`)


### PR DESCRIPTION
Fixes the BTC swap contract address to be the same as specified in the frontend repo.


Before
```
Tokenized BTC swap address: 0xf5059a5D33d5853360D16C683c16e67980206f36
Tokenized BTC swap token address: 0x55652FF92Dc17a21AD6810Cce2F4703fa2339CAE
```

After
```
Tokenized BTC swap address: 0x851356ae760d987E095750cCeb3bC6014560891C
Tokenized BTC swap token address: 0xB955b6c65Ff69bfe07A557aa385055282b8a5eA3
```