### PR TITLE
Use a different signer when deploying libraries to preserve the nonce of the main signer

### DIFF
--- a/deploy/002_deploy_MathUtils.ts
+++ b/deploy/002_deploy_MathUtils.ts
@@ -4,10 +4,10 @@ import { DeployFunction } from "hardhat-deploy/types"
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts } = hre
   const { deploy } = deployments
-  const { deployer } = await getNamedAccounts()
+  const { libraryDeployer } = await getNamedAccounts()
 
   await deploy("MathUtils", {
-    from: deployer,
+    from: libraryDeployer,
     log: true,
     skipIfAlreadyDeployed: true,
   })

--- a/deploy/003_deploy_SwapUtilsGuarded.ts
+++ b/deploy/003_deploy_SwapUtilsGuarded.ts
@@ -4,10 +4,10 @@ import { DeployFunction } from "hardhat-deploy/types"
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts } = hre
   const { deploy, get } = deployments
-  const { deployer } = await getNamedAccounts()
+  const { libraryDeployer } = await getNamedAccounts()
 
   await deploy("SwapUtilsGuarded", {
-    from: deployer,
+    from: libraryDeployer,
     log: true,
     libraries: {
       MathUtils: (await get("MathUtils")).address,

--- a/deploy/004_deploy_SwapUtils.ts
+++ b/deploy/004_deploy_SwapUtils.ts
@@ -4,10 +4,10 @@ import { DeployFunction } from "hardhat-deploy/types"
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts } = hre
   const { deploy, get } = deployments
-  const { deployer } = await getNamedAccounts()
+  const { libraryDeployer } = await getNamedAccounts()
 
   await deploy("SwapUtils", {
-    from: deployer,
+    from: libraryDeployer,
     log: true,
     libraries: {
       MathUtils: (await get("MathUtils")).address,

--- a/deploy/006_deploy_Swap.ts
+++ b/deploy/006_deploy_Swap.ts
@@ -6,10 +6,10 @@ import { MULTISIG_ADDRESS } from "../utils/accounts"
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts } = hre
   const { deploy, get } = deployments
-  const { deployer } = await getNamedAccounts()
+  const { libraryDeployer } = await getNamedAccounts()
 
   await deploy("Swap", {
-    from: deployer,
+    from: libraryDeployer,
     log: true,
     libraries: {
       SwapUtils: (await get("SwapUtils")).address,

--- a/deploy/006_deploy_SwapFlashLoan.ts
+++ b/deploy/006_deploy_SwapFlashLoan.ts
@@ -6,10 +6,10 @@ import { MULTISIG_ADDRESS } from "../utils/accounts"
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts } = hre
   const { deploy, get } = deployments
-  const { deployer } = await getNamedAccounts()
+  const { libraryDeployer } = await getNamedAccounts()
 
   await deploy("SwapFlashLoan", {
-    from: deployer,
+    from: libraryDeployer,
     log: true,
     libraries: {
       SwapUtils: (await get("SwapUtils")).address,

--- a/deploy/111_deploy_USDPool.ts
+++ b/deploy/111_deploy_USDPool.ts
@@ -44,7 +44,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       (e: any) => e["event"] == "NewSwapPool",
     )
     const usdSwapAddress = newPoolEvent["args"]["swapAddress"]
-    console.log(
+    log(
       `deployed USD pool clone (targeting "SwapFlashLoan") at ${usdSwapAddress}`,
     )
     await save("SaddleUSDPool", {

--- a/deploy/121_deploy_VETH2Pool.ts
+++ b/deploy/121_deploy_VETH2Pool.ts
@@ -43,7 +43,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       (e: any) => e["event"] == "NewSwapPool",
     )
     const veth2SwapAddress = newPoolEvent["args"]["swapAddress"]
-    console.log(
+    log(
       `deployed vETH2 pool (targeting "SwapFlashLoan") at ${veth2SwapAddress}`,
     )
     await save("SaddleVETH2Pool", {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -59,6 +59,10 @@ let config: HardhatUserConfig = {
       default: 0, // here this will by default take the first account as deployer
       1: 0, // similarly on mainnet it will take the first account as deployer. Note though that depending on how hardhat network are configured, the account 0 on one network can be different than on another
     },
+    libraryDeployer: {
+      default: 1, // use a different account for deploying libraries on the hardhat network
+      1: 0, // use the same address as the main deployer on mainnet
+    },
   },
 }
 


### PR DESCRIPTION
(This PR only affects the localhost deployments). 

In the future, additional libraries and auxiliary contracts should be deployed by the `libraryDeployer` namedSigner. This allows us to keep the addresses of user facing contracts that are required by the frontend as the same.