### PR TITLE
Remove hardcoded artifacts path in favor of using `ethers.getContractFactory`

### DIFF
--- a/test/allowlist.ts
+++ b/test/allowlist.ts
@@ -4,7 +4,7 @@ import {
   getTestMerkleAllowedAccounts,
   getTestMerkleRoot,
 } from "./testUtils"
-import { deployContract, solidity } from "ethereum-waffle"
+import { solidity } from "ethereum-waffle"
 import { deployments, ethers } from "hardhat"
 
 import { Allowlist } from "../build/typechain/Allowlist"
@@ -21,7 +21,6 @@ const ALLOWED_ACCOUNTS = getTestMerkleAllowedAccounts()
 
 describe("Allowlist", () => {
   let signers: Array<Signer>
-  let owner: Signer
   let malActor: Signer
   let allowlist: Allowlist
 
@@ -30,7 +29,6 @@ describe("Allowlist", () => {
       await deployments.fixture() // ensure you start from a fresh deployments
 
       signers = await ethers.getSigners()
-      owner = signers[0]
       malActor = signers[10]
 
       const cf = await ethers.getContractFactory("Allowlist")

--- a/test/allowlist.ts
+++ b/test/allowlist.ts
@@ -8,7 +8,6 @@ import { deployContract, solidity } from "ethereum-waffle"
 import { deployments, ethers } from "hardhat"
 
 import { Allowlist } from "../build/typechain/Allowlist"
-import AllowlistArtifact from "../build/artifacts/contracts/guarded/Allowlist.sol/Allowlist.json"
 import { Signer } from "ethers"
 import chai from "chai"
 import { formatBytes32String } from "ethers/lib/utils"
@@ -33,9 +32,9 @@ describe("Allowlist", () => {
       signers = await ethers.getSigners()
       owner = signers[0]
       malActor = signers[10]
-      allowlist = (await deployContract(owner, AllowlistArtifact, [
-        getTestMerkleRoot(),
-      ])) as Allowlist
+
+      const cf = await ethers.getContractFactory("Allowlist")
+      allowlist = (await cf.deploy(getTestMerkleRoot())) as Allowlist
     },
   )
 

--- a/test/flashloan.ts
+++ b/test/flashloan.ts
@@ -8,15 +8,10 @@ import {
 import { deployContract, solidity } from "ethereum-waffle"
 
 import { GenericERC20 } from "../build/typechain/GenericERC20"
-import GenericERC20Artifact from "../build/artifacts/contracts/helper/GenericERC20.sol/GenericERC20.json"
 import { LPToken } from "../build/typechain/LPToken"
-import LPTokenArtifact from "../build/artifacts/contracts/LPToken.sol/LPToken.json"
 import { FlashLoanBorrowerExample } from "../build/typechain/FlashLoanBorrowerExample"
-import FlashLoanBorrowerExampleArtifact from "../build/artifacts/contracts/helper/FlashLoanBorrowerExample.sol/FlashLoanBorrowerExample.json"
 import { SwapFlashLoan } from "../build/typechain/SwapFlashLoan"
-import SwapFlashLoanArtifact from "../build/artifacts/contracts/SwapFlashLoan.sol/SwapFlashLoan.json"
 import { SwapUtils } from "../build/typechain/SwapUtils"
-import SwapUtilsArtifact from "../build/artifacts/contracts/SwapUtils.sol/SwapUtils.json"
 import chai from "chai"
 import { deployments, ethers } from "hardhat"
 import { solidityPack } from "ethers/lib/utils"
@@ -73,30 +68,13 @@ describe("Swap Flashloan", () => {
       user1Address = await user1.getAddress()
       user2Address = await user2.getAddress()
 
+      const erc20Factory = await ethers.getContractFactory("GenericERC20")
+
       // Deploy dummy tokens
-      DAI = (await deployContract(owner as Wallet, GenericERC20Artifact, [
-        "DAI",
-        "DAI",
-        "18",
-      ])) as GenericERC20
-
-      USDC = (await deployContract(owner as Wallet, GenericERC20Artifact, [
-        "USDC",
-        "USDC",
-        "6",
-      ])) as GenericERC20
-
-      USDT = (await deployContract(owner as Wallet, GenericERC20Artifact, [
-        "USDT",
-        "USDT",
-        "6",
-      ])) as GenericERC20
-
-      SUSD = (await deployContract(owner as Wallet, GenericERC20Artifact, [
-        "SUSD",
-        "SUSD",
-        "18",
-      ])) as GenericERC20
+      DAI = (await erc20Factory.deploy("DAI", "DAI", "18")) as GenericERC20
+      USDC = (await erc20Factory.deploy("USDC", "USDC", "6")) as GenericERC20
+      USDT = (await erc20Factory.deploy("USDT", "USDT", "6")) as GenericERC20
+      SUSD = (await erc20Factory.deploy("SUSD", "SUSD", "18")) as GenericERC20
 
       TOKENS.push(DAI, USDC, USDT, SUSD)
 
@@ -111,16 +89,18 @@ describe("Swap Flashloan", () => {
         },
       )
 
-      // Deploy Swap with SwapUtils library
-      swapFlashLoan = (await deployContractWithLibraries(
-        owner,
-        SwapFlashLoanArtifact,
+      const swapFlashLoanFactory = await ethers.getContractFactory(
+        "SwapFlashLoan",
         {
-          SwapUtils: (await get("SwapUtils")).address,
-          AmplificationUtils: (await get("AmplificationUtils")).address,
+          libraries: {
+            SwapUtils: (await get("SwapUtils")).address,
+            AmplificationUtils: (await get("AmplificationUtils")).address,
+          },
         },
-      )) as SwapFlashLoan
-      await swapFlashLoan.deployed()
+      )
+
+      // Deploy Swap with SwapUtils library
+      swapFlashLoan = (await swapFlashLoanFactory.deploy()) as SwapFlashLoan
 
       await swapFlashLoan.initialize(
         [DAI.address, USDC.address, USDT.address, SUSD.address],
@@ -138,7 +118,7 @@ describe("Swap Flashloan", () => {
       swapStorage = await swapFlashLoan.swapStorage()
 
       swapToken = (await ethers.getContractAt(
-        LPTokenArtifact.abi,
+        "LPToken",
         swapStorage.lpToken,
       )) as LPToken
 
@@ -165,11 +145,10 @@ describe("Swap Flashloan", () => {
       )
 
       // Deploy an example flash loan borrower contract
-      flashLoanExample = (await deployContract(
-        signers[0] as Wallet,
-        FlashLoanBorrowerExampleArtifact,
-      )) as FlashLoanBorrowerExample
-      await flashLoanExample.deployed()
+      const flashLoanExampleFactory = await ethers.getContractFactory(
+        "FlashLoanBorrowerExample",
+      )
+      flashLoanExample = (await flashLoanExampleFactory.deploy()) as FlashLoanBorrowerExample
 
       // Set fees to easier numbers for debugging
       await swapFlashLoan.setFlashLoanFees(100, 5000)

--- a/test/flashloan.ts
+++ b/test/flashloan.ts
@@ -1,17 +1,11 @@
-import { BigNumber, Signer, Wallet } from "ethers"
-import {
-  MAX_UINT256,
-  deployContractWithLibraries,
-  getUserTokenBalance,
-  asyncForEach,
-} from "./testUtils"
-import { deployContract, solidity } from "ethereum-waffle"
+import { BigNumber, Signer } from "ethers"
+import { MAX_UINT256, getUserTokenBalance, asyncForEach } from "./testUtils"
+import { solidity } from "ethereum-waffle"
 
 import { GenericERC20 } from "../build/typechain/GenericERC20"
 import { LPToken } from "../build/typechain/LPToken"
 import { FlashLoanBorrowerExample } from "../build/typechain/FlashLoanBorrowerExample"
 import { SwapFlashLoan } from "../build/typechain/SwapFlashLoan"
-import { SwapUtils } from "../build/typechain/SwapUtils"
 import chai from "chai"
 import { deployments, ethers } from "hardhat"
 import { solidityPack } from "ethers/lib/utils"
@@ -22,7 +16,6 @@ const { expect } = chai
 describe("Swap Flashloan", () => {
   let signers: Array<Signer>
   let swapFlashLoan: SwapFlashLoan
-  let swapUtils: SwapUtils
   let flashLoanExample: FlashLoanBorrowerExample
   let DAI: GenericERC20
   let USDC: GenericERC20

--- a/test/genericERC20.ts
+++ b/test/genericERC20.ts
@@ -1,5 +1,5 @@
-import { Signer, Wallet } from "ethers"
-import { deployContract, solidity } from "ethereum-waffle"
+import { Signer } from "ethers"
+import { solidity } from "ethereum-waffle"
 
 import { GenericERC20 } from "../build/typechain/GenericERC20"
 import chai from "chai"

--- a/test/genericERC20.ts
+++ b/test/genericERC20.ts
@@ -1,7 +1,6 @@
 import { Signer, Wallet } from "ethers"
 import { deployContract, solidity } from "ethereum-waffle"
 
-import GenericERC20Artifact from "../build/artifacts/contracts/helper/GenericERC20.sol/GenericERC20.json"
 import { GenericERC20 } from "../build/typechain/GenericERC20"
 import chai from "chai"
 import { ethers } from "hardhat"
@@ -17,12 +16,14 @@ describe("GenericERC20", async () => {
   it("Reverts when minting 0", async () => {
     signers = await ethers.getSigners()
     owner = signers[0]
+
     // Deploy dummy tokens
-    firstToken = (await deployContract(owner as Wallet, GenericERC20Artifact, [
+    const erc20Factory = await ethers.getContractFactory("GenericERC20")
+    firstToken = (await erc20Factory.deploy(
       "First Token",
       "FIRST",
       "18",
-    ])) as GenericERC20
+    )) as GenericERC20
     await expect(firstToken.mint(await owner.getAddress(), 0)).to.be.reverted
   })
 })

--- a/test/lpToken.ts
+++ b/test/lpToken.ts
@@ -1,7 +1,6 @@
 import { Signer, Wallet } from "ethers"
 import { deployContract, solidity } from "ethereum-waffle"
 
-import LPTokenArtifact from "../build/artifacts/contracts/LPToken.sol/LPToken.json"
 import { LPToken } from "../build/typechain/LPToken"
 import chai from "chai"
 import { ethers } from "hardhat"
@@ -18,11 +17,12 @@ describe("LPToken", async () => {
     signers = await ethers.getSigners()
     owner = signers[0]
     // Deploy dummy tokens
-    firstToken = (await deployContract(owner as Wallet, LPTokenArtifact, [
+    const lpTokenFactory = await ethers.getContractFactory("LPToken")
+    firstToken = (await lpTokenFactory.deploy(
       "First Token",
       "FIRST",
       "18",
-    ])) as LPToken
+    )) as LPToken
     await expect(firstToken.mint(await owner.getAddress(), 0)).to.be.reverted
   })
 })

--- a/test/lpToken.ts
+++ b/test/lpToken.ts
@@ -1,5 +1,5 @@
-import { Signer, Wallet } from "ethers"
-import { deployContract, solidity } from "ethereum-waffle"
+import { Signer } from "ethers"
+import { solidity } from "ethereum-waffle"
 
 import { LPToken } from "../build/typechain/LPToken"
 import chai from "chai"

--- a/test/mathUtils.ts
+++ b/test/mathUtils.ts
@@ -1,8 +1,7 @@
-import { Signer, Wallet, constants } from "ethers"
-import { deployContract, solidity } from "ethereum-waffle"
+import { constants } from "ethers"
+import { solidity } from "ethereum-waffle"
 
 import { TestMathUtils } from "../build/typechain/TestMathUtils"
-import TestMathUtilsArtifact from "../build/artifacts/contracts/helper/test/TestMathUtils.sol/TestMathUtils.json"
 import chai from "chai"
 import { ethers } from "hardhat"
 
@@ -10,16 +9,13 @@ chai.use(solidity)
 const { expect } = chai
 
 describe("MathUtils", () => {
-  let signers: Array<Signer>
-
   let mathUtils: TestMathUtils
 
   beforeEach(async () => {
-    signers = await ethers.getSigners()
-    mathUtils = (await deployContract(
-      signers[0] as Wallet,
-      TestMathUtilsArtifact,
-    )) as TestMathUtils
+    const testMathUtilsFactory = await ethers.getContractFactory(
+      "TestMathUtils",
+    )
+    mathUtils = (await testMathUtilsFactory.deploy()) as TestMathUtils
   })
 
   describe("within1", () => {

--- a/test/stakeableTokenWrapper.ts
+++ b/test/stakeableTokenWrapper.ts
@@ -1,5 +1,5 @@
 import { Signer, Wallet } from "ethers"
-import { deployContract, solidity } from "ethereum-waffle"
+import { solidity } from "ethereum-waffle"
 import { deployments, ethers } from "hardhat"
 
 import { GenericERC20 } from "../build/typechain/GenericERC20"

--- a/test/stakeableTokenWrapper.ts
+++ b/test/stakeableTokenWrapper.ts
@@ -3,10 +3,8 @@ import { deployContract, solidity } from "ethereum-waffle"
 import { deployments, ethers } from "hardhat"
 
 import { GenericERC20 } from "../build/typechain/GenericERC20"
-import GenericERC20Artifact from "../build/artifacts/contracts/helper/GenericERC20.sol/GenericERC20.json"
 import { IERC20 } from "../build/typechain/IERC20"
 import { StakeableTokenWrapper } from "../build/typechain/StakeableTokenWrapper"
-import StakeableTokenWrapperArtifact from "../build/artifacts/contracts/StakeableTokenWrapper.sol/StakeableTokenWrapper.json"
 import chai from "chai"
 
 chai.use(solidity)
@@ -19,12 +17,8 @@ describe("StakeableTokenWrapper", () => {
   let tokenWrapper: StakeableTokenWrapper
 
   async function deployWrapper(token: IERC20): Promise<StakeableTokenWrapper> {
-    const contract = (await deployContract(
-      signers[0] as Wallet,
-      StakeableTokenWrapperArtifact,
-      [token.address],
-    )) as StakeableTokenWrapper
-    return contract
+    const factory = await ethers.getContractFactory("StakeableTokenWrapper")
+    return factory.deploy(token.address) as Promise<StakeableTokenWrapper>
   }
 
   async function approveAndStake(
@@ -45,10 +39,11 @@ describe("StakeableTokenWrapper", () => {
       await deployments.fixture() // ensure you start from a fresh deployments
 
       signers = await ethers.getSigners()
-      basicToken = (await deployContract(
-        signers[0] as Wallet,
-        GenericERC20Artifact,
-        ["Basic Token", "BASIC", "18"],
+      const erc20Factory = await ethers.getContractFactory("GenericERC20")
+      basicToken = (await erc20Factory.deploy(
+        "Basic Token",
+        "BASIC",
+        "18",
       )) as GenericERC20
 
       await basicToken.mint(await signers[0].getAddress(), 10 ** 10)

--- a/test/swap.ts
+++ b/test/swap.ts
@@ -1,10 +1,9 @@
-import { BigNumber, Signer, Wallet } from "ethers"
+import { BigNumber, Signer } from "ethers"
 import {
   MAX_UINT256,
   TIME,
   ZERO_ADDRESS,
   asyncForEach,
-  deployContractWithLibraries,
   getCurrentBlockTimestamp,
   getUserTokenBalance,
   getUserTokenBalances,
@@ -12,7 +11,7 @@ import {
   setTimestamp,
   forceAdvanceOneBlock,
 } from "./testUtils"
-import { deployContract, solidity } from "ethereum-waffle"
+import { solidity } from "ethereum-waffle"
 import { deployments, ethers } from "hardhat"
 
 import { GenericERC20 } from "../build/typechain/GenericERC20"

--- a/test/swap.ts
+++ b/test/swap.ts
@@ -16,15 +16,10 @@ import { deployContract, solidity } from "ethereum-waffle"
 import { deployments, ethers } from "hardhat"
 
 import { GenericERC20 } from "../build/typechain/GenericERC20"
-import GenericERC20Artifact from "../build/artifacts/contracts/helper/GenericERC20.sol/GenericERC20.json"
 import { LPToken } from "../build/typechain/LPToken"
-import LPTokenArtifact from "../build/artifacts/contracts/LPToken.sol/LPToken.json"
 import { Swap } from "../build/typechain/Swap"
-import SwapArtifact from "../build/artifacts/contracts/Swap.sol/Swap.json"
 import { SwapUtils } from "../build/typechain/SwapUtils"
-import SwapUtilsArtifact from "../build/artifacts/contracts/SwapUtils.sol/SwapUtils.json"
 import { TestSwapReturnValues } from "../build/typechain/TestSwapReturnValues"
-import TestSwapReturnValuesArtifact from "../build/artifacts/contracts/helper/test/TestSwapReturnValues.sol/TestSwapReturnValues.json"
 import chai from "chai"
 
 chai.use(solidity)
@@ -74,16 +69,18 @@ describe("Swap", async () => {
       user2Address = await user2.getAddress()
 
       // Deploy dummy tokens
-      firstToken = (await deployContract(
-        owner as Wallet,
-        GenericERC20Artifact,
-        ["First Token", "FIRST", "18"],
+      const erc20Factory = await ethers.getContractFactory("GenericERC20")
+
+      firstToken = (await erc20Factory.deploy(
+        "First Token",
+        "FIRST",
+        "18",
       )) as GenericERC20
 
-      secondToken = (await deployContract(
-        owner as Wallet,
-        GenericERC20Artifact,
-        ["Second Token", "SECOND", "18"],
+      secondToken = (await erc20Factory.deploy(
+        "Second Token",
+        "SECOND",
+        "18",
       )) as GenericERC20
 
       // Mint dummy tokens
@@ -94,11 +91,13 @@ describe("Swap", async () => {
       })
 
       // Deploy Swap with SwapUtils library
-      swap = (await deployContractWithLibraries(owner, SwapArtifact, {
-        SwapUtils: (await get("SwapUtils")).address,
-        AmplificationUtils: (await get("AmplificationUtils")).address,
-      })) as Swap
-      await swap.deployed()
+      const swapFactory = await ethers.getContractFactory("Swap", {
+        libraries: {
+          SwapUtils: (await get("SwapUtils")).address,
+          AmplificationUtils: (await get("AmplificationUtils")).address,
+        },
+      })
+      swap = (await swapFactory.deploy()) as Swap
 
       await swap.initialize(
         [firstToken.address, secondToken.address],
@@ -116,16 +115,18 @@ describe("Swap", async () => {
       swapStorage = await swap.swapStorage()
 
       swapToken = (await ethers.getContractAt(
-        LPTokenArtifact.abi,
+        "LPToken",
         swapStorage.lpToken,
       )) as LPToken
 
-      testSwapReturnValues = (await deployContract(
-        owner,
-        TestSwapReturnValuesArtifact,
-        [swap.address, swapToken.address, 2],
+      const testSwapReturnValuesFactory = await ethers.getContractFactory(
+        "TestSwapReturnValues",
+      )
+      testSwapReturnValues = (await testSwapReturnValuesFactory.deploy(
+        swap.address,
+        swapToken.address,
+        2,
       )) as TestSwapReturnValues
-      await testSwapReturnValues.deployed()
 
       await asyncForEach([owner, user1, user2], async (signer) => {
         await firstToken.connect(signer).approve(swap.address, MAX_UINT256)

--- a/test/swap4tokens.ts
+++ b/test/swap4tokens.ts
@@ -3,24 +3,19 @@ import {
   MAX_UINT256,
   TIME,
   asyncForEach,
-  deployContractWithLibraries,
   getCurrentBlockTimestamp,
   getPoolBalances,
   getUserTokenBalance,
   getUserTokenBalances,
   setTimestamp,
 } from "./testUtils"
-import { deployContract, solidity } from "ethereum-waffle"
+import { solidity } from "ethereum-waffle"
 import { deployments, ethers } from "hardhat"
 
 import { GenericERC20 } from "../build/typechain/GenericERC20"
-import GenericERC20Artifact from "../build/artifacts/contracts/helper/GenericERC20.sol/GenericERC20.json"
 import { LPToken } from "../build/typechain/LPToken"
-import LPTokenArtifact from "../build/artifacts/contracts/LPToken.sol/LPToken.json"
 import { Swap } from "../build/typechain/Swap"
-import SwapArtifact from "../build/artifacts/contracts/Swap.sol/Swap.json"
 import { SwapUtils } from "../build/typechain/SwapUtils"
-import SwapUtilsArtifact from "../build/artifacts/contracts/SwapUtils.sol/SwapUtils.json"
 import chai from "chai"
 
 chai.use(solidity)
@@ -75,29 +70,12 @@ describe("Swap with 4 tokens", () => {
       user2Address = await user2.getAddress()
 
       // Deploy dummy tokens
-      DAI = (await deployContract(owner as Wallet, GenericERC20Artifact, [
-        "DAI",
-        "DAI",
-        "18",
-      ])) as GenericERC20
+      const erc20Factory = await ethers.getContractFactory("GenericERC20")
 
-      USDC = (await deployContract(owner as Wallet, GenericERC20Artifact, [
-        "USDC",
-        "USDC",
-        "6",
-      ])) as GenericERC20
-
-      USDT = (await deployContract(owner as Wallet, GenericERC20Artifact, [
-        "USDT",
-        "USDT",
-        "6",
-      ])) as GenericERC20
-
-      SUSD = (await deployContract(owner as Wallet, GenericERC20Artifact, [
-        "SUSD",
-        "SUSD",
-        "18",
-      ])) as GenericERC20
+      DAI = (await erc20Factory.deploy("DAI", "DAI", "18")) as GenericERC20
+      USDC = (await erc20Factory.deploy("USDC", "USDC", "6")) as GenericERC20
+      USDT = (await erc20Factory.deploy("USDT", "USDT", "6")) as GenericERC20
+      SUSD = (await erc20Factory.deploy("SUSD", "SUSD", "18")) as GenericERC20
 
       TOKENS.push(DAI, USDC, USDT, SUSD)
 
@@ -113,11 +91,13 @@ describe("Swap with 4 tokens", () => {
       )
 
       // Deploy Swap with SwapUtils library
-      swap = (await deployContractWithLibraries(owner, SwapArtifact, {
-        SwapUtils: (await get("SwapUtils")).address,
-        AmplificationUtils: (await get("AmplificationUtils")).address,
-      })) as Swap
-      await swap.deployed()
+      const swapFactory = await ethers.getContractFactory("Swap", {
+        libraries: {
+          SwapUtils: (await get("SwapUtils")).address,
+          AmplificationUtils: (await get("AmplificationUtils")).address,
+        },
+      })
+      swap = (await swapFactory.deploy()) as Swap
 
       await swap.initialize(
         [DAI.address, USDC.address, USDT.address, SUSD.address],
@@ -135,7 +115,7 @@ describe("Swap with 4 tokens", () => {
       swapStorage = await swap.swapStorage()
 
       swapToken = (await ethers.getContractAt(
-        LPTokenArtifact.abi,
+        "LPToken",
         swapStorage.lpToken,
       )) as LPToken
 

--- a/test/swap4tokens.ts
+++ b/test/swap4tokens.ts
@@ -1,4 +1,4 @@
-import { BigNumber, Signer, Wallet } from "ethers"
+import { BigNumber, Signer } from "ethers"
 import {
   MAX_UINT256,
   TIME,

--- a/test/swapDeployer.ts
+++ b/test/swapDeployer.ts
@@ -1,7 +1,6 @@
-import { BigNumber, Signer, Wallet } from "ethers"
+import { BigNumber, Signer } from "ethers"
 import {
   MAX_UINT256,
-  deployContractWithLibraries,
   getCurrentBlockTimestamp,
   getUserTokenBalance,
   asyncForEach,
@@ -11,7 +10,7 @@ import {
   getPoolBalances,
   forceAdvanceOneBlock,
 } from "./testUtils"
-import { deployContract, solidity } from "ethereum-waffle"
+import { solidity } from "ethereum-waffle"
 
 import { GenericERC20 } from "../build/typechain/GenericERC20"
 import { LPToken } from "../build/typechain/LPToken"

--- a/test/swapDeployer.ts
+++ b/test/swapDeployer.ts
@@ -14,15 +14,10 @@ import {
 import { deployContract, solidity } from "ethereum-waffle"
 
 import { GenericERC20 } from "../build/typechain/GenericERC20"
-import GenericERC20Artifact from "../build/artifacts/contracts/helper/GenericERC20.sol/GenericERC20.json"
 import { LPToken } from "../build/typechain/LPToken"
-import LPTokenArtifact from "../build/artifacts/contracts/LPToken.sol/LPToken.json"
 import { Swap } from "../build/typechain/Swap"
-import SwapArtifact from "../build/artifacts/contracts/Swap.sol/Swap.json"
 import { SwapDeployer } from "../build/typechain/SwapDeployer"
-import SwapDeployerArtifact from "../build/artifacts/contracts/SwapDeployer.sol/SwapDeployer.json"
 import { SwapUtils } from "../build/typechain/SwapUtils"
-import SwapUtilsArtifact from "../build/artifacts/contracts/SwapUtils.sol/SwapUtils.json"
 import chai from "chai"
 import { deployments, ethers } from "hardhat"
 
@@ -80,29 +75,12 @@ describe("Swap Deployer", () => {
       user2Address = await user2.getAddress()
 
       // Deploy dummy tokens
-      DAI = (await deployContract(owner as Wallet, GenericERC20Artifact, [
-        "DAI",
-        "DAI",
-        "18",
-      ])) as GenericERC20
+      const erc20Factory = await ethers.getContractFactory("GenericERC20")
 
-      USDC = (await deployContract(owner as Wallet, GenericERC20Artifact, [
-        "USDC",
-        "USDC",
-        "6",
-      ])) as GenericERC20
-
-      USDT = (await deployContract(owner as Wallet, GenericERC20Artifact, [
-        "USDT",
-        "USDT",
-        "6",
-      ])) as GenericERC20
-
-      SUSD = (await deployContract(owner as Wallet, GenericERC20Artifact, [
-        "SUSD",
-        "SUSD",
-        "18",
-      ])) as GenericERC20
+      DAI = (await erc20Factory.deploy("DAI", "DAI", "18")) as GenericERC20
+      USDC = (await erc20Factory.deploy("USDC", "USDC", "6")) as GenericERC20
+      USDT = (await erc20Factory.deploy("USDT", "USDT", "6")) as GenericERC20
+      SUSD = (await erc20Factory.deploy("SUSD", "SUSD", "18")) as GenericERC20
 
       TOKENS.push(DAI, USDC, USDT, SUSD)
 
@@ -118,16 +96,18 @@ describe("Swap Deployer", () => {
       )
 
       // Deploy Swap with SwapUtils library
-      swap = (await deployContractWithLibraries(owner, SwapArtifact, {
-        SwapUtils: (await get("SwapUtils")).address,
-        AmplificationUtils: (await get("AmplificationUtils")).address,
-      })) as Swap
-      await swap.deployed()
+      const swapFactory = await ethers.getContractFactory("Swap", {
+        libraries: {
+          SwapUtils: (await get("SwapUtils")).address,
+          AmplificationUtils: (await get("AmplificationUtils")).address,
+        },
+      })
+      swap = (await swapFactory.deploy()) as Swap
 
-      swapDeployer = (await deployContract(
-        owner,
-        SwapDeployerArtifact,
-      )) as SwapDeployer
+      const swapDeployerFactory = await ethers.getContractFactory(
+        "SwapDeployer",
+      )
+      swapDeployer = (await swapDeployerFactory.deploy()) as SwapDeployer
 
       const swapCloneAddress = await swapDeployer.callStatic.deploy(
         swap.address,
@@ -153,17 +133,14 @@ describe("Swap Deployer", () => {
         0,
       )
 
-      swapClone = (await ethers.getContractAt(
-        SwapArtifact.abi,
-        swapCloneAddress,
-      )) as Swap
+      swapClone = (await ethers.getContractAt("Swap", swapCloneAddress)) as Swap
 
       expect(await swapClone.getVirtualPrice()).to.be.eq(0)
 
       swapStorage = await swapClone.swapStorage()
 
       swapToken = (await ethers.getContractAt(
-        LPTokenArtifact.abi,
+        "LPToken",
         swapStorage.lpToken,
       )) as LPToken
 

--- a/test/swapInitialize.ts
+++ b/test/swapInitialize.ts
@@ -4,11 +4,8 @@ import { deployContract, solidity } from "ethereum-waffle"
 import { deployments, ethers } from "hardhat"
 
 import { GenericERC20 } from "../build/typechain/GenericERC20"
-import GenericERC20Artifact from "../build/artifacts/contracts/helper/GenericERC20.sol/GenericERC20.json"
 import { Swap } from "../build/typechain/Swap"
-import SwapArtifact from "../build/artifacts/contracts/Swap.sol/Swap.json"
 import { SwapUtils } from "../build/typechain/SwapUtils"
-import SwapUtilsArtifact from "../build/artifacts/contracts/SwapUtils.sol/SwapUtils.json"
 import chai from "chai"
 
 chai.use(solidity)
@@ -37,23 +34,27 @@ describe("Swap", () => {
       owner = signers[0]
 
       // Deploy dummy tokens
-      firstToken = (await deployContract(
-        owner as Wallet,
-        GenericERC20Artifact,
-        ["First Token", "FIRST", "18"],
+      const erc20Factory = await ethers.getContractFactory("GenericERC20")
+
+      firstToken = (await erc20Factory.deploy(
+        "First Token",
+        "FIRST",
+        "18",
       )) as GenericERC20
 
-      secondToken = (await deployContract(
-        owner as Wallet,
-        GenericERC20Artifact,
-        ["Second Token", "SECOND", "18"],
+      secondToken = (await erc20Factory.deploy(
+        "Second Token",
+        "SECOND",
+        "18",
       )) as GenericERC20
 
-      swap = (await deployContractWithLibraries(owner, SwapArtifact, {
-        SwapUtils: (await get("SwapUtils")).address,
-        AmplificationUtils: (await get("AmplificationUtils")).address,
-      })) as Swap
-      await swap.deployed()
+      const swapFactory = await ethers.getContractFactory("Swap", {
+        libraries: {
+          SwapUtils: (await get("SwapUtils")).address,
+          AmplificationUtils: (await get("AmplificationUtils")).address,
+        },
+      })
+      swap = (await swapFactory.deploy()) as Swap
     },
   )
 

--- a/test/swapInitialize.ts
+++ b/test/swapInitialize.ts
@@ -1,11 +1,10 @@
-import { Signer, Wallet } from "ethers"
-import { ZERO_ADDRESS, deployContractWithLibraries } from "./testUtils"
-import { deployContract, solidity } from "ethereum-waffle"
+import { Signer } from "ethers"
+import { ZERO_ADDRESS } from "./testUtils"
+import { solidity } from "ethereum-waffle"
 import { deployments, ethers } from "hardhat"
 
 import { GenericERC20 } from "../build/typechain/GenericERC20"
 import { Swap } from "../build/typechain/Swap"
-import { SwapUtils } from "../build/typechain/SwapUtils"
 import chai from "chai"
 
 chai.use(solidity)
@@ -13,7 +12,6 @@ const { expect } = chai
 
 describe("Swap", () => {
   let signers: Array<Signer>
-  let swapUtils: SwapUtils
   let swap: Swap
   let firstToken: GenericERC20
   let secondToken: GenericERC20

--- a/test/virtualBridge.ts
+++ b/test/virtualBridge.ts
@@ -1,26 +1,20 @@
-import { BigNumber, Signer, Wallet, utils } from "ethers"
+import { BigNumber, Signer, utils } from "ethers"
 import {
   MAX_UINT256,
   asyncForEach,
-  deployContractWithLibraries,
   getUserTokenBalances,
   impersonateAccount,
   increaseTimestamp,
   setTimestamp,
 } from "./testUtils"
-import { deployContract, solidity } from "ethereum-waffle"
+import { solidity } from "ethereum-waffle"
 import { deployments, ethers, network } from "hardhat"
 
 import { Bridge } from "../build/typechain/Bridge"
-import BridgeArtifact from "../build/artifacts/contracts/VirtualSwap/Bridge.sol/Bridge.json"
 import { GenericERC20 } from "../build/typechain/GenericERC20"
-import GenericERC20Artifact from "../build/artifacts/contracts/helper/GenericERC20.sol/GenericERC20.json"
 import { LPToken } from "../build/typechain/LPToken"
-import LPTokenArtifact from "../build/artifacts/contracts/LPToken.sol/LPToken.json"
 import { Swap } from "../build/typechain/Swap"
-import SwapArtifact from "../build/artifacts/contracts/Swap.sol/Swap.json"
 import { SwapUtils } from "../build/typechain/SwapUtils"
-import SwapUtilsArtifact from "../build/artifacts/contracts/SwapUtils.sol/SwapUtils.json"
 import chai from "chai"
 import dotenv from "dotenv"
 
@@ -166,7 +160,7 @@ describe("Virtual swap bridge [ @skip-on-coverage ]", () => {
       // eslint-disable-next-line no-unused-vars
       for (const [k, v] of Object.entries(tokenList)) {
         const contract = (await ethers.getContractAt(
-          GenericERC20Artifact.abi,
+          "GenericERC20",
           v.address,
         )) as GenericERC20
 
@@ -204,11 +198,14 @@ describe("Virtual swap bridge [ @skip-on-coverage ]", () => {
       expect(balances[5]).to.eq("315600946507951")
 
       // Deploy Swap with SwapUtils library
-      btcSwap = (await deployContractWithLibraries(owner, SwapArtifact, {
-        SwapUtils: (await get("SwapUtils")).address,
-        AmplificationUtils: (await get("AmplificationUtils")).address,
-      })) as Swap
-      await btcSwap.deployed()
+      const swapFactory = await ethers.getContractFactory("Swap", {
+        libraries: {
+          SwapUtils: (await get("SwapUtils")).address,
+          AmplificationUtils: (await get("AmplificationUtils")).address,
+        },
+      })
+      btcSwap = (await swapFactory.deploy()) as Swap
+
       await btcSwap.initialize(
         [
           tokenList.tbtc.address,
@@ -227,15 +224,11 @@ describe("Virtual swap bridge [ @skip-on-coverage ]", () => {
       btcSwapStorage = await btcSwap.swapStorage()
 
       btcSwapToken = (await ethers.getContractAt(
-        LPTokenArtifact.abi,
+        "LPToken",
         btcSwapStorage.lpToken,
       )) as LPToken
 
-      usdSwap = (await deployContractWithLibraries(owner, SwapArtifact, {
-        SwapUtils: (await get("SwapUtils")).address,
-        AmplificationUtils: (await get("AmplificationUtils")).address,
-      })) as Swap
-      await usdSwap.deployed()
+      usdSwap = (await swapFactory.deploy()) as Swap
       await usdSwap.initialize(
         [tokenList.susd.address, tokenList.usdc.address],
         [18, 6],
@@ -248,8 +241,8 @@ describe("Virtual swap bridge [ @skip-on-coverage ]", () => {
       )
 
       // Deploy Bridge contract
-      bridge = (await deployContract(owner, BridgeArtifact)) as Bridge
-      await bridge.deployed()
+      const bridgeFactory = await ethers.getContractFactory("Bridge")
+      bridge = (await bridgeFactory.deploy()) as Bridge
 
       // Approve token transfer to Swap for adding liquidity and to Bridge for virtual swaps
       await asyncForEach(
@@ -943,7 +936,7 @@ describe("Virtual swap bridge [ @skip-on-coverage ]", () => {
             queueId,
           )
           const synth = (await ethers.getContractAt(
-            GenericERC20Artifact.abi,
+            "GenericERC20",
             await bridge.getProxyAddressFromTargetSynthKey(
               pendingToTokenSwap.synthKey,
             ),
@@ -966,7 +959,7 @@ describe("Virtual swap bridge [ @skip-on-coverage ]", () => {
             queueId,
           )
           const synth = (await ethers.getContractAt(
-            GenericERC20Artifact.abi,
+            "GenericERC20",
             await bridge.getProxyAddressFromTargetSynthKey(
               pendingToTokenSwap.synthKey,
             ),
@@ -997,7 +990,7 @@ describe("Virtual swap bridge [ @skip-on-coverage ]", () => {
             queueId,
           )
           const synth = (await ethers.getContractAt(
-            GenericERC20Artifact.abi,
+            "GenericERC20",
             await bridge.getProxyAddressFromTargetSynthKey(
               pendingToTokenSwap.synthKey,
             ),

--- a/test/virtualBridge.ts
+++ b/test/virtualBridge.ts
@@ -14,7 +14,6 @@ import { Bridge } from "../build/typechain/Bridge"
 import { GenericERC20 } from "../build/typechain/GenericERC20"
 import { LPToken } from "../build/typechain/LPToken"
 import { Swap } from "../build/typechain/Swap"
-import { SwapUtils } from "../build/typechain/SwapUtils"
 import chai from "chai"
 import dotenv from "dotenv"
 
@@ -46,7 +45,6 @@ describe("Virtual swap bridge [ @skip-on-coverage ]", () => {
   let bridge: Bridge
   let btcSwap: Swap
   let usdSwap: Swap
-  let swapUtils: SwapUtils
   let wbtc: GenericERC20
   let renbtc: GenericERC20
   let sbtc: GenericERC20


### PR DESCRIPTION
This will allow using the same test files between OVM and L1.