### PR TITLE
Remove withdraw fee feature

### DIFF
--- a/contracts/LPToken.sol
+++ b/contracts/LPToken.sol
@@ -56,6 +56,5 @@ contract LPToken is ERC20BurnableUpgradeable, OwnableUpgradeable {
     ) internal virtual override(ERC20Upgradeable) {
         super._beforeTokenTransfer(from, to, amount);
         require(to != address(this), "LPToken: cannot send to itself");
-        ISwap(owner()).updateUserWithdrawFee(to, amount);
     }
 }

--- a/contracts/SwapDeployer.sol
+++ b/contracts/SwapDeployer.sol
@@ -24,7 +24,6 @@ contract SwapDeployer is Ownable {
         uint256 _a,
         uint256 _fee,
         uint256 _adminFee,
-        uint256 _withdrawFee,
         address lpTokenTargetAddress
     ) external returns (address) {
         address swapClone = Clones.clone(swapAddress);
@@ -36,7 +35,6 @@ contract SwapDeployer is Ownable {
             _a,
             _fee,
             _adminFee,
-            _withdrawFee,
             lpTokenTargetAddress
         );
         Ownable(swapClone).transferOwnership(owner());

--- a/contracts/SwapFlashLoan.sol
+++ b/contracts/SwapFlashLoan.sol
@@ -56,7 +56,6 @@ contract SwapFlashLoan is Swap {
      * StableSwap paper for details
      * @param _fee default swap fee to be initialized with
      * @param _adminFee default adminFee to be initialized with
-     * @param _withdrawFee default withdrawFee to be initialized with
      * @param lpTokenTargetAddress the address of an existing LPToken contract to use as a target
      */
     function initialize(
@@ -67,7 +66,6 @@ contract SwapFlashLoan is Swap {
         uint256 _a,
         uint256 _fee,
         uint256 _adminFee,
-        uint256 _withdrawFee,
         address lpTokenTargetAddress
     ) public virtual override initializer {
         Swap.initialize(
@@ -78,7 +76,6 @@ contract SwapFlashLoan is Swap {
             _a,
             _fee,
             _adminFee,
-            _withdrawFee,
             lpTokenTargetAddress
         );
         flashLoanFeeBPS = 8; // 8 bps

--- a/contracts/interfaces/IMetaSwap.sol
+++ b/contracts/interfaces/IMetaSwap.sol
@@ -31,19 +31,17 @@ interface IMetaSwap {
         uint256 dx
     ) external view returns (uint256);
 
-    function calculateTokenAmount(
-        address account,
-        uint256[] calldata amounts,
-        bool deposit
-    ) external view returns (uint256);
+    function calculateTokenAmount(uint256[] calldata amounts, bool deposit)
+        external
+        view
+        returns (uint256);
 
-    function calculateRemoveLiquidity(address account, uint256 amount)
+    function calculateRemoveLiquidity(uint256 amount)
         external
         view
         returns (uint256[] memory);
 
     function calculateRemoveLiquidityOneToken(
-        address account,
         uint256 tokenAmount,
         uint8 tokenIndex
     ) external view returns (uint256 availableTokenAmount);
@@ -56,8 +54,7 @@ interface IMetaSwap {
         string memory lpTokenSymbol,
         uint256 a,
         uint256 fee,
-        uint256 adminFee,
-        uint256 withdrawFee
+        uint256 adminFee
     ) external;
 
     function swap(
@@ -100,8 +97,4 @@ interface IMetaSwap {
         uint256 maxBurnAmount,
         uint256 deadline
     ) external returns (uint256);
-
-    // withdraw fee update function
-    function updateUserWithdrawFee(address recipient, uint256 transferAmount)
-        external;
 }

--- a/contracts/interfaces/ISwap.sol
+++ b/contracts/interfaces/ISwap.sol
@@ -28,19 +28,17 @@ interface ISwap {
         uint256 dx
     ) external view returns (uint256);
 
-    function calculateTokenAmount(
-        address account,
-        uint256[] calldata amounts,
-        bool deposit
-    ) external view returns (uint256);
+    function calculateTokenAmount(uint256[] calldata amounts, bool deposit)
+        external
+        view
+        returns (uint256);
 
-    function calculateRemoveLiquidity(address account, uint256 amount)
+    function calculateRemoveLiquidity(uint256 amount)
         external
         view
         returns (uint256[] memory);
 
     function calculateRemoveLiquidityOneToken(
-        address account,
         uint256 tokenAmount,
         uint8 tokenIndex
     ) external view returns (uint256 availableTokenAmount);
@@ -54,7 +52,6 @@ interface ISwap {
         uint256 a,
         uint256 fee,
         uint256 adminFee,
-        uint256 withdrawFee,
         address lpTokenTargetAddress
     ) external;
 
@@ -90,8 +87,4 @@ interface ISwap {
         uint256 maxBurnAmount,
         uint256 deadline
     ) external returns (uint256);
-
-    // withdraw fee update function
-    function updateUserWithdrawFee(address recipient, uint256 transferAmount)
-        external;
 }

--- a/contracts/meta/MetaSwap.sol
+++ b/contracts/meta/MetaSwap.sol
@@ -116,7 +116,6 @@ contract MetaSwap is Swap {
      *
      * @dev This shouldn't be used outside frontends for user estimates.
      *
-     * @param account address that is depositing or withdrawing tokens
      * @param amounts an array of token amounts to deposit or withdrawal,
      * corresponding to pooledTokens. The amount should be in each
      * pooled token's native precision. If a token charges a fee on transfers,
@@ -124,16 +123,17 @@ contract MetaSwap is Swap {
      * @param deposit whether this is a deposit or a withdrawal
      * @return token amount the user will receive
      */
-    function calculateTokenAmount(
-        address account,
-        uint256[] calldata amounts,
-        bool deposit
-    ) external view virtual override returns (uint256) {
+    function calculateTokenAmount(uint256[] calldata amounts, bool deposit)
+        external
+        view
+        virtual
+        override
+        returns (uint256)
+    {
         return
             MetaSwapUtils.calculateTokenAmount(
                 swapStorage,
                 metaSwapStorage,
-                account,
                 amounts,
                 deposit
             );
@@ -142,14 +142,12 @@ contract MetaSwap is Swap {
     /**
      * @notice Calculate the amount of underlying token available to withdraw
      * when withdrawing via only single token
-     * @param account the address that is withdrawing tokens
      * @param tokenAmount the amount of LP token to burn
      * @param tokenIndex index of which token will be withdrawn
      * @return availableTokenAmount calculated amount of underlying token
      * available to withdraw
      */
     function calculateRemoveLiquidityOneToken(
-        address account,
         uint256 tokenAmount,
         uint8 tokenIndex
     ) external view virtual override returns (uint256) {
@@ -157,7 +155,6 @@ contract MetaSwap is Swap {
             MetaSwapUtils.calculateWithdrawOneToken(
                 swapStorage,
                 metaSwapStorage,
-                account,
                 tokenAmount,
                 tokenIndex
             );
@@ -178,7 +175,6 @@ contract MetaSwap is Swap {
      * StableSwap paper for details
      * @param _fee default swap fee to be initialized with
      * @param _adminFee default adminFee to be initialized with
-     * @param _withdrawFee default withdrawFee to be initialized with
      */
     function initialize(
         IERC20[] memory _pooledTokens,
@@ -188,7 +184,6 @@ contract MetaSwap is Swap {
         uint256 _a,
         uint256 _fee,
         uint256 _adminFee,
-        uint256 _withdrawFee,
         address lpTokenTargetAddress
     ) public virtual override initializer {
         revert("use initializeMetaSwap() instead");
@@ -216,7 +211,6 @@ contract MetaSwap is Swap {
      * StableSwap paper for details
      * @param _fee default swap fee to be initialized with
      * @param _adminFee default adminFee to be initialized with
-     * @param _withdrawFee default withdrawFee to be initialized with
      */
     function initializeMetaSwap(
         IERC20[] memory _pooledTokens,
@@ -226,7 +220,6 @@ contract MetaSwap is Swap {
         uint256 _a,
         uint256 _fee,
         uint256 _adminFee,
-        uint256 _withdrawFee,
         address lpTokenTargetAddress,
         ISwap baseSwap
     ) external virtual initializer {
@@ -238,7 +231,6 @@ contract MetaSwap is Swap {
             _a,
             _fee,
             _adminFee,
-            _withdrawFee,
             lpTokenTargetAddress
         );
 

--- a/deploy/111_deploy_USDPool.ts
+++ b/deploy/111_deploy_USDPool.ts
@@ -23,7 +23,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     const INITIAL_A = 200
     const SWAP_FEE = 4e6 // 4bps
     const ADMIN_FEE = 0
-    const WITHDRAW_FEE = 0
 
     const receipt = await execute(
       "SwapDeployer",
@@ -39,7 +38,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       INITIAL_A,
       SWAP_FEE,
       ADMIN_FEE,
-      WITHDRAW_FEE,
       (
         await get("LPToken")
       ).address,

--- a/deploy/121_deploy_VETH2Pool.ts
+++ b/deploy/121_deploy_VETH2Pool.ts
@@ -22,7 +22,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     const INITIAL_A = 10
     const SWAP_FEE = 4e6 // 4bps
     const ADMIN_FEE = 0
-    const WITHDRAW_FEE = 0
 
     const receipt = await execute(
       "SwapDeployer",
@@ -38,7 +37,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       INITIAL_A,
       SWAP_FEE,
       ADMIN_FEE,
-      WITHDRAW_FEE,
       (
         await get("LPToken")
       ).address,

--- a/test/flashloan.ts
+++ b/test/flashloan.ts
@@ -103,7 +103,6 @@ describe("Swap Flashloan", () => {
         INITIAL_A_VALUE,
         SWAP_FEE,
         0,
-        0,
         (
           await deployments.get("LPToken")
         ).address,

--- a/test/metaSwap.ts
+++ b/test/metaSwap.ts
@@ -167,7 +167,6 @@ describe("Meta-Swap", async () => {
         INITIAL_A_VALUE,
         SWAP_FEE,
         0,
-        0,
         (
           await get("LPToken")
         ).address,
@@ -299,11 +298,7 @@ describe("Meta-Swap", async () => {
       await expect(
         metaSwap
           .connect(user1)
-          .calculateTokenAmount(
-            user1Address,
-            [MAX_UINT256, String(3e18)],
-            false,
-          ),
+          .calculateTokenAmount([MAX_UINT256, String(3e18)], false),
       ).to.be.revertedWith("Cannot withdraw more than available")
     })
 
@@ -320,7 +315,7 @@ describe("Meta-Swap", async () => {
     it("Succeeds with expected output amount of pool tokens", async () => {
       const calculatedPoolTokenAmount = await metaSwap
         .connect(user1)
-        .calculateTokenAmount(user1Address, [String(1e18), String(3e18)], true)
+        .calculateTokenAmount([String(1e18), String(3e18)], true)
 
       const calculatedPoolTokenAmountWithSlippage = calculatedPoolTokenAmount
         .mul(999)
@@ -343,7 +338,7 @@ describe("Meta-Swap", async () => {
     it("Succeeds with actual pool token amount being within ±0.1% range of calculated pool token", async () => {
       const calculatedPoolTokenAmount = await metaSwap
         .connect(user1)
-        .calculateTokenAmount(user1Address, [String(1e18), String(3e18)], true)
+        .calculateTokenAmount([String(1e18), String(3e18)], true)
 
       const calculatedPoolTokenAmountWithNegativeSlippage =
         calculatedPoolTokenAmount.mul(999).div(1000)
@@ -395,7 +390,7 @@ describe("Meta-Swap", async () => {
     it("Reverts when minToMint is not reached due to front running", async () => {
       const calculatedLPTokenAmount = await metaSwap
         .connect(user1)
-        .calculateTokenAmount(user1Address, [String(1e18), String(3e18)], true)
+        .calculateTokenAmount([String(1e18), String(3e18)], true)
 
       const calculatedLPTokenAmountWithSlippage = calculatedLPTokenAmount
         .mul(999)
@@ -433,7 +428,7 @@ describe("Meta-Swap", async () => {
     it("Emits addLiquidity event", async () => {
       const calculatedLPTokenAmount = await metaSwap
         .connect(user1)
-        .calculateTokenAmount(user1Address, [String(2e18), String(1e16)], true)
+        .calculateTokenAmount([String(2e18), String(1e16)], true)
 
       const calculatedLPTokenAmountWithSlippage = calculatedLPTokenAmount
         .mul(999)
@@ -454,7 +449,7 @@ describe("Meta-Swap", async () => {
   describe("removeLiquidity", () => {
     it("Reverts with 'Cannot exceed total supply'", async () => {
       await expect(
-        metaSwap.calculateRemoveLiquidity(ZERO_ADDRESS, MAX_UINT256),
+        metaSwap.calculateRemoveLiquidity(MAX_UINT256),
       ).to.be.revertedWith("Cannot exceed total supply")
     })
 
@@ -504,10 +499,7 @@ describe("Meta-Swap", async () => {
       )
 
       const [expectedFirstTokenAmount, expectedSecondTokenAmount] =
-        await metaSwap.calculateRemoveLiquidity(
-          user1Address,
-          poolTokenBalanceBefore,
-        )
+        await metaSwap.calculateRemoveLiquidity(poolTokenBalanceBefore)
 
       expect(expectedFirstTokenAmount).to.eq(
         BigNumber.from("1498601924450190405"),
@@ -582,10 +574,7 @@ describe("Meta-Swap", async () => {
       expect(currentUser1Balance).to.eq(BigNumber.from("1996275270169644725"))
 
       const [expectedFirstTokenAmount, expectedSecondTokenAmount] =
-        await metaSwap.calculateRemoveLiquidity(
-          user1Address,
-          currentUser1Balance,
-        )
+        await metaSwap.calculateRemoveLiquidity(currentUser1Balance)
 
       expect(expectedFirstTokenAmount).to.eq(
         BigNumber.from("1498601924450190405"),
@@ -723,7 +712,6 @@ describe("Meta-Swap", async () => {
 
       // User 1 calculates amount of pool token to be burned
       const maxPoolTokenAmountToBeBurned = await metaSwap.calculateTokenAmount(
-        user1Address,
         [String(1e18), String(1e16)],
         false,
       )
@@ -830,7 +818,6 @@ describe("Meta-Swap", async () => {
 
       // User 1 calculates amount of pool token to be burned
       const maxPoolTokenAmountToBeBurned = await metaSwap.calculateTokenAmount(
-        user1Address,
         [String(1e18), String(1e16)],
         false,
       )
@@ -934,7 +921,7 @@ describe("Meta-Swap", async () => {
 
     it("Reverts with 'Token index out of range'", async () => {
       await expect(
-        metaSwap.calculateRemoveLiquidityOneToken(ZERO_ADDRESS, 1, 5),
+        metaSwap.calculateRemoveLiquidityOneToken(1, 5),
       ).to.be.revertedWith("Token index out of range")
     })
 
@@ -948,7 +935,6 @@ describe("Meta-Swap", async () => {
 
       await expect(
         metaSwap.calculateRemoveLiquidityOneToken(
-          user1Address,
           currentUser1Balance.mul(2),
           0,
         ),
@@ -971,11 +957,7 @@ describe("Meta-Swap", async () => {
 
       // User 1 calculates the amount of underlying token to receive.
       const calculatedFirstTokenAmount =
-        await metaSwap.calculateRemoveLiquidityOneToken(
-          user1Address,
-          currentUser1Balance,
-          0,
-        )
+        await metaSwap.calculateRemoveLiquidityOneToken(currentUser1Balance, 0)
       expect(calculatedFirstTokenAmount).to.eq(
         BigNumber.from("2008990034631583696"),
       )
@@ -1038,11 +1020,7 @@ describe("Meta-Swap", async () => {
 
       // User 1 calculates the amount of underlying token to receive.
       const calculatedFirstTokenAmount =
-        await metaSwap.calculateRemoveLiquidityOneToken(
-          user1Address,
-          currentUser1Balance,
-          0,
-        )
+        await metaSwap.calculateRemoveLiquidityOneToken(currentUser1Balance, 0)
       expect(calculatedFirstTokenAmount).to.eq(
         BigNumber.from("2008990034631583696"),
       )
@@ -1819,945 +1797,6 @@ describe("Meta-Swap", async () => {
       expect(secondTokenAfter.sub(secondTokenBefore)).to.eq(
         BigNumber.from("1000980987206499309"),
       )
-    })
-  })
-
-  describe("Test withdrawal fees on removeLiquidity", () => {
-    beforeEach(async () => {
-      expect(await metaLPToken.balanceOf(user1Address)).to.eq(0)
-      await metaSwap.setDefaultWithdrawFee(String(5e7))
-      await metaLPToken.connect(user1).approve(metaSwap.address, MAX_UINT256)
-    })
-
-    it("Removing liquidity immediately after deposit", async () => {
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(1e18), String(1e18)], 0, MAX_UINT256)
-
-      const currentPoolTokenBalance = await metaLPToken.balanceOf(user1Address)
-
-      const depositTimestamp = (
-        await metaSwap.getDepositTimestamp(user1Address)
-      ).toNumber()
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(5e7),
-      )
-
-      const expectedTokenAmounts = await metaSwap.calculateRemoveLiquidity(
-        user1Address,
-        currentPoolTokenBalance,
-      )
-      expect(expectedTokenAmounts[0]).to.eq("995000000000000000")
-      expect(expectedTokenAmounts[1]).to.eq("995000000000000000")
-
-      const expectedTokenAmountsWithoutWithdrawalFee =
-        await metaSwap.calculateRemoveLiquidity(
-          ZERO_ADDRESS,
-          currentPoolTokenBalance,
-        )
-      expect(expectedTokenAmountsWithoutWithdrawalFee[0]).to.eq(String(1e18))
-      expect(expectedTokenAmountsWithoutWithdrawalFee[1]).to.eq(String(1e18))
-
-      const [firstBalanceBefore, secondBalanceBefore] =
-        await getUserTokenBalances(user1, [susd, baseLPToken])
-
-      // Manually set the timestamp between addLiquidity and removeLiquidity to 1 second
-      await setNextTimestamp(depositTimestamp + 1)
-      await metaSwap
-        .connect(user1)
-        .removeLiquidity(currentPoolTokenBalance, [0, 0], MAX_UINT256)
-
-      const [firstBalanceAfter, secondBalanceAfter] =
-        await getUserTokenBalances(user1, [susd, baseLPToken])
-
-      // Returned amounts are about 99.5% of initial deposits
-      expect(firstBalanceAfter.sub(firstBalanceBefore)).to.eq(
-        "995000002100000000",
-      )
-      expect(secondBalanceAfter.sub(secondBalanceBefore)).to.eq(
-        "995000002100000000",
-      )
-    })
-
-    it("Removing liquidity 2 weeks after deposit", async () => {
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(1e18), String(1e18)], 0, MAX_UINT256)
-
-      const depositTimestamp = (
-        await metaSwap.getDepositTimestamp(user1Address)
-      ).toNumber()
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(5e7),
-      )
-
-      const [firstBalanceBefore, secondBalanceBefore] =
-        await getUserTokenBalances(user1, [susd, baseLPToken])
-      const currentPoolTokenBalance = await metaLPToken.balanceOf(user1Address)
-
-      // 2 weeks = 2 * 604800 seconds
-      await setTimestamp(depositTimestamp + 2 * TIME.WEEKS - 1)
-
-      const expectedTokenAmounts = await metaSwap.calculateRemoveLiquidity(
-        user1Address,
-        currentPoolTokenBalance,
-      )
-      expect(expectedTokenAmounts[0]).to.eq("997499998000000000")
-      expect(expectedTokenAmounts[1]).to.eq("997499998000000000")
-
-      const expectedTokenAmountsWithoutWithdrawalFee =
-        await metaSwap.calculateRemoveLiquidity(
-          ZERO_ADDRESS,
-          currentPoolTokenBalance,
-        )
-      expect(expectedTokenAmountsWithoutWithdrawalFee[0]).to.eq(String(1e18))
-      expect(expectedTokenAmountsWithoutWithdrawalFee[1]).to.eq(String(1e18))
-
-      await setNextTimestamp(depositTimestamp + 2 * TIME.WEEKS)
-      await metaSwap
-        .connect(user1)
-        .removeLiquidity(currentPoolTokenBalance, [0, 0], MAX_UINT256)
-
-      const [firstBalanceAfter, secondBalanceAfter] =
-        await getUserTokenBalances(user1, [susd, baseLPToken])
-
-      // Returned amounts are 99.75% of initial deposits
-      expect(firstBalanceAfter.sub(firstBalanceBefore)).to.eq(
-        "997500000000000000",
-      )
-      expect(secondBalanceAfter.sub(secondBalanceBefore)).to.eq(
-        "997500000000000000",
-      )
-    })
-
-    it("Removing liquidity 4 weeks after deposit", async () => {
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(1e18), String(1e18)], 0, MAX_UINT256)
-
-      const depositTimestamp = (
-        await metaSwap.getDepositTimestamp(user1Address)
-      ).toNumber()
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(5e7),
-      )
-
-      const [firstBalanceBefore, secondBalanceBefore] =
-        await getUserTokenBalances(user1, [susd, baseLPToken])
-
-      const currentPoolTokenBalance = await metaLPToken.balanceOf(user1Address)
-
-      // 4 weeks = 4 * 604800 seconds
-      await setTimestamp(depositTimestamp + 4 * TIME.WEEKS)
-      const expectedTokenAmounts = await metaSwap.calculateRemoveLiquidity(
-        user1Address,
-        currentPoolTokenBalance,
-      )
-      expect(expectedTokenAmounts[0]).to.eq(String(1e18))
-      expect(expectedTokenAmounts[1]).to.eq(String(1e18))
-
-      const expectedTokenAmountsWithoutWithdrawalFee =
-        await metaSwap.calculateRemoveLiquidity(
-          ZERO_ADDRESS,
-          currentPoolTokenBalance,
-        )
-      expect(expectedTokenAmountsWithoutWithdrawalFee[0]).to.eq(String(1e18))
-      expect(expectedTokenAmountsWithoutWithdrawalFee[1]).to.eq(String(1e18))
-
-      await metaSwap
-        .connect(user1)
-        .removeLiquidity(currentPoolTokenBalance, [0, 0], MAX_UINT256)
-
-      const [firstBalanceAfter, secondBalanceAfter] =
-        await getUserTokenBalances(user1, [susd, baseLPToken])
-
-      // Returned amounts are 100% of initial deposits
-      expect(firstBalanceAfter.sub(firstBalanceBefore)).to.eq(
-        "1000000000000000000",
-      )
-      expect(secondBalanceAfter.sub(secondBalanceBefore)).to.eq(
-        "1000000000000000000",
-      )
-    })
-  })
-
-  describe("Test withdrawal fees on removeLiquidityOne", async () => {
-    beforeEach(async () => {
-      await metaLPToken.approve(metaSwap.address, MAX_UINT256)
-      await metaSwap.removeLiquidity(
-        await metaLPToken.balanceOf(ownerAddress),
-        [0, 0],
-        MAX_UINT256,
-      )
-      expect(await metaLPToken.totalSupply()).to.eq(0)
-      await metaSwap.setDefaultWithdrawFee(String(5e7))
-
-      // reset the pool
-      await metaSwap.addLiquidity([String(1e19), String(1e19)], 0, MAX_UINT256)
-      await metaLPToken.connect(user1).approve(metaSwap.address, MAX_UINT256)
-    })
-
-    it("Removing liquidity immediately after deposit", async () => {
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(1e18), String(1e18)], 0, MAX_UINT256)
-      const depositTimestamp = (
-        await metaSwap.getDepositTimestamp(user1Address)
-      ).toNumber()
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(5e7),
-      )
-
-      const firstBalanceBefore = await getUserTokenBalance(user1, susd)
-      const swapTokenBalance = await getUserTokenBalance(user1, metaLPToken)
-
-      const expectedFirstTokenAmount =
-        await metaSwap.calculateRemoveLiquidityOneToken(
-          user1Address,
-          swapTokenBalance,
-          0,
-        )
-      expect(expectedFirstTokenAmount).to.eq("1987041984559878425")
-
-      const expectedFirstTokenAmountWithoutWithdrawalFee =
-        await metaSwap.calculateRemoveLiquidityOneToken(
-          ZERO_ADDRESS,
-          swapTokenBalance,
-          0,
-        )
-      expect(expectedFirstTokenAmountWithoutWithdrawalFee).to.eq(
-        "1997027120160681835",
-      )
-
-      await setNextTimestamp(depositTimestamp + 1)
-      await metaSwap
-        .connect(user1)
-        .removeLiquidityOneToken(swapTokenBalance, 0, 0, MAX_UINT256)
-
-      const firstBalanceAfter = await getUserTokenBalance(user1, susd)
-
-      // Close to 1987041984559878425
-      expect(firstBalanceAfter.sub(firstBalanceBefore)).to.eq(
-        "1987041988753635378",
-      )
-    })
-
-    it("Removing liquidity 2 weeks after deposit", async () => {
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(1e18), String(1e18)], 0, MAX_UINT256)
-      const depositTimestamp = (
-        await metaSwap.getDepositTimestamp(user1Address)
-      ).toNumber()
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(5e7),
-      )
-
-      const [firstBalanceBefore, swapTokenBalance] = await getUserTokenBalances(
-        user1,
-        [susd, metaLPToken],
-      )
-
-      const initiallyExpectedFirstTokenAmount =
-        await metaSwap.calculateRemoveLiquidityOneToken(
-          user1Address,
-          swapTokenBalance,
-          0,
-        )
-      expect(initiallyExpectedFirstTokenAmount).to.eq("1987041984559878425")
-
-      const expectedFirstTokenAmountWithoutWithdrawalFee =
-        await metaSwap.calculateRemoveLiquidityOneToken(
-          ZERO_ADDRESS,
-          swapTokenBalance,
-          0,
-        )
-      expect(expectedFirstTokenAmountWithoutWithdrawalFee).to.eq(
-        "1997027120160681835",
-      )
-
-      await setTimestamp(depositTimestamp + 2 * TIME.WEEKS - 1)
-
-      const expectedFirstTokenAmount =
-        await metaSwap.calculateRemoveLiquidityOneToken(
-          user1Address,
-          swapTokenBalance,
-          0,
-        )
-      expect(expectedFirstTokenAmount).to.eq("1992034548366225890")
-
-      await setNextTimestamp(depositTimestamp + 2 * TIME.WEEKS)
-
-      await metaSwap
-        .connect(user1)
-        .removeLiquidityOneToken(swapTokenBalance, 0, 0, MAX_UINT256)
-
-      const firstBalanceAfter = await getUserTokenBalance(user1, susd)
-
-      // 1997027120160681835 * 99.75% = 1992034552360280130
-      expect(firstBalanceAfter.sub(firstBalanceBefore)).to.eq(
-        "1992034552360280130",
-      )
-    })
-
-    it("Removing liquidity 4 weeks after deposit", async () => {
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(1e18), String(1e18)], 0, MAX_UINT256)
-      const depositTimestamp = (
-        await metaSwap.getDepositTimestamp(user1Address)
-      ).toNumber()
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(5e7),
-      )
-
-      const [firstBalanceBefore, swapTokenBalance] = await getUserTokenBalances(
-        user1,
-        [susd, metaLPToken],
-      )
-
-      const initiallyExpectedFirstTokenAmount =
-        await metaSwap.calculateRemoveLiquidityOneToken(
-          user1Address,
-          swapTokenBalance,
-          0,
-        )
-      expect(initiallyExpectedFirstTokenAmount).to.eq("1987041984559878425")
-
-      const expectedFirstTokenAmountWithoutWithdrawalFee =
-        await metaSwap.calculateRemoveLiquidityOneToken(
-          ZERO_ADDRESS,
-          swapTokenBalance,
-          0,
-        )
-      expect(expectedFirstTokenAmountWithoutWithdrawalFee).to.eq(
-        "1997027120160681835",
-      )
-
-      await setTimestamp(depositTimestamp + 4 * TIME.WEEKS)
-
-      const expectedFirstTokenAmount =
-        await metaSwap.calculateRemoveLiquidityOneToken(
-          user1Address,
-          swapTokenBalance,
-          0,
-        )
-      expect(expectedFirstTokenAmount).to.eq("1997027120160681835")
-
-      await metaSwap
-        .connect(user1)
-        .removeLiquidityOneToken(swapTokenBalance, 0, 0, MAX_UINT256)
-
-      const firstBalanceAfter = await getUserTokenBalance(user1, susd)
-
-      // 1997027120160681835 * 100%
-      expect(firstBalanceAfter.sub(firstBalanceBefore)).to.eq(
-        "1997027120160681835",
-      )
-    })
-  })
-
-  describe("Test withdrawal fees on removeLiquidityImbalance", async () => {
-    beforeEach(async () => {
-      await metaLPToken.approve(metaSwap.address, MAX_UINT256)
-      await metaSwap.removeLiquidity(
-        await metaLPToken.balanceOf(ownerAddress),
-        [0, 0],
-        MAX_UINT256,
-      )
-      expect(await metaLPToken.totalSupply()).to.eq(0)
-      await metaSwap.setDefaultWithdrawFee(String(5e7))
-
-      // reset the pool
-      await metaSwap.addLiquidity([String(1e19), String(1e19)], 0, MAX_UINT256)
-      await metaLPToken.connect(user1).approve(metaSwap.address, MAX_UINT256)
-    })
-
-    it("Removing liquidity immediately after deposit", async () => {
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(1e18), String(1e18)], 0, MAX_UINT256)
-      const depositTimestamp = (
-        await metaSwap.getDepositTimestamp(user1Address)
-      ).toNumber()
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(5e7),
-      )
-
-      const [firstTokenBefore, secondTokenBefore, swapTokenBefore] =
-        await getUserTokenBalances(user1, [susd, baseLPToken, metaLPToken])
-
-      const expectedBurnAmount = await metaSwap.calculateTokenAmount(
-        user1Address,
-        [String(1e18), String(1e17)],
-        false,
-      )
-      expect(expectedBurnAmount).to.eq("1105910196876519474")
-
-      const expectedBurnAmountWithoutWithdrawalFee =
-        await metaSwap.calculateTokenAmount(
-          ZERO_ADDRESS,
-          [String(1e18), String(1e17)],
-          false,
-        )
-      expect(expectedBurnAmountWithoutWithdrawalFee).to.eq(
-        "1100380645892136877",
-      )
-
-      await setNextTimestamp(depositTimestamp + 1)
-      await metaSwap
-        .connect(user1)
-        .removeLiquidityImbalance(
-          [String(1e18), String(1e17)],
-          swapTokenBefore,
-          MAX_UINT256,
-        )
-
-      const [firstTokenAfter, secondTokenAfter, swapTokenAfter] =
-        await getUserTokenBalances(user1, [susd, baseLPToken, metaLPToken])
-
-      expect(firstTokenAfter.sub(firstTokenBefore)).to.eq(String(1e18))
-      expect(secondTokenAfter.sub(secondTokenBefore)).to.eq(String(1e17))
-
-      // Below comparison with defaultWithdrawFee set to zero results in 1100830653956319289
-      // Total amount of burned token should be close to
-      // 1100830653956319289 / 0.995
-
-      // Actual amount burned / expected amount burned = 1.00040895461
-      expect(swapTokenBefore.sub(swapTokenAfter)).to.eq("1106362463952721723")
-    })
-
-    it("Removing liquidity 2 weeks after deposit", async () => {
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(1e18), String(1e18)], 0, MAX_UINT256)
-      const depositTimestamp = (
-        await metaSwap.getDepositTimestamp(user1Address)
-      ).toNumber()
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(5e7),
-      )
-
-      const [firstTokenBefore, secondTokenBefore, swapTokenBefore] =
-        await getUserTokenBalances(user1, [susd, baseLPToken, metaLPToken])
-
-      await setTimestamp(depositTimestamp + 2 * TIME.WEEKS - 1)
-
-      const expectedBurnAmount = await metaSwap.calculateTokenAmount(
-        user1Address,
-        [String(1e18), String(1e17)],
-        false,
-      )
-      expect(expectedBurnAmount).to.eq("1103138494334249489")
-
-      const expectedBurnAmountWithoutWithdrawalFee =
-        await metaSwap.calculateTokenAmount(
-          ZERO_ADDRESS,
-          [String(1e18), String(1e17)],
-          false,
-        )
-      expect(expectedBurnAmountWithoutWithdrawalFee).to.eq(
-        "1100380645892136877",
-      )
-
-      await setNextTimestamp(depositTimestamp + 2 * TIME.WEEKS)
-      await metaSwap
-        .connect(user1)
-        .removeLiquidityImbalance(
-          [String(1e18), String(1e17)],
-          swapTokenBefore,
-          MAX_UINT256,
-        )
-
-      const [firstTokenAfter, secondTokenAfter, swapTokenAfter] =
-        await getUserTokenBalances(user1, [susd, baseLPToken, metaLPToken])
-
-      expect(firstTokenAfter.sub(firstTokenBefore)).to.eq(String(1e18))
-      expect(secondTokenAfter.sub(secondTokenBefore)).to.eq(String(1e17))
-
-      // 1100830653956319289 / 0.9975 = 1103589628026385252
-      // Actual amount burned / expected amount burned = 1.00040895472
-      expect(swapTokenBefore.sub(swapTokenAfter)).to.eq("1103589628026385252")
-    })
-
-    it("Removing liquidity 4 weeks after deposit", async () => {
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(1e18), String(1e18)], 0, MAX_UINT256)
-      const depositTimestamp = (
-        await metaSwap.getDepositTimestamp(user1Address)
-      ).toNumber()
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(5e7),
-      )
-
-      const [firstTokenBefore, secondTokenBefore, swapTokenBefore] =
-        await getUserTokenBalances(user1, [susd, baseLPToken, metaLPToken])
-
-      await setTimestamp(depositTimestamp + 4 * TIME.WEEKS)
-
-      const expectedBurnAmount = await metaSwap.calculateTokenAmount(
-        user1Address,
-        [String(1e18), String(1e17)],
-        false,
-      )
-      expect(expectedBurnAmount).to.eq("1100380645892136877")
-
-      const expectedBurnAmountWithoutWithdrawalFee =
-        await metaSwap.calculateTokenAmount(
-          ZERO_ADDRESS,
-          [String(1e18), String(1e17)],
-          false,
-        )
-      expect(expectedBurnAmountWithoutWithdrawalFee).to.eq(
-        "1100380645892136877",
-      )
-
-      await metaSwap
-        .connect(user1)
-        .removeLiquidityImbalance(
-          [String(1e18), String(1e17)],
-          swapTokenBefore,
-          MAX_UINT256,
-        )
-
-      const [firstTokenAfter, secondTokenAfter, swapTokenAfter] =
-        await getUserTokenBalances(user1, [susd, baseLPToken, metaLPToken])
-
-      expect(firstTokenAfter.sub(firstTokenBefore)).to.eq(String(1e18))
-      expect(secondTokenAfter.sub(secondTokenBefore)).to.eq(String(1e17))
-
-      // 1100830653956319289 / 1.0000 = 1100830653956319289
-      // Actual amount burned / expected amount burned = 1.00040895672
-      expect(swapTokenBefore.sub(swapTokenAfter)).to.eq("1100830653956319289")
-    })
-  })
-
-  describe("Verify changing withdraw fee works as expected", async () => {
-    // This test ensures that changing withdraw fee impacts deposits made in the past
-    //
-    // [Cases when withdraw fee is increased]
-    // - When fee is increased from 0
-    // Current balance and last deposit time is used for fee calculation.
-    // Therefore the fee decays from full amount since the last deposit.
-    // If the last deposit was more than 4 weeks prior to the fee increase, fee should be 0.
-    //
-    // - When fee is increased from x% to y%, where x > 0
-    // Discounts from past deposits should apply accordingly and total fee should increase by rate of (y/x).
-    //
-    // [Cases when withdraw fee is decreased]
-    // - When fee is decreased to 0
-    // Fee should be 0 regardless when the user last deposited.
-    //
-    // - When fee is decreased from x% to y%, where y > 0
-    // Discounts from past deposits should apply accordingly and total fee should decrease by rate of (y/x).
-
-    it("Increase withdraw fee from 0% to 0.5%, immediately after last deposit", async () => {
-      // User 2 adds liquidity once when fee is 0%
-      await metaSwap
-        .connect(user2)
-        .addLiquidity(
-          [String(1e18), String(1e18)],
-          0,
-          (await getCurrentBlockTimestamp()) + 60,
-        )
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        0,
-      )
-
-      // User 2 adds liquidity again at 2 weeks time
-      const nextTimestamp = (await getCurrentBlockTimestamp()) + TIME.WEEKS * 2
-      await setNextTimestamp(nextTimestamp)
-      await metaSwap
-        .connect(user2)
-        .addLiquidity([String(1e18), String(1e18)], 0, nextTimestamp + 60)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        0,
-      )
-
-      // Fee is updated to 0.5%
-      await metaSwap.setDefaultWithdrawFee(String(5e7))
-
-      // Fee should linearly decay from 0.5% to 0% since the last deposit
-      // (Fee is bit less than 0.5% because `swap.setDefaultWithdrawFee` is called one block after the last deposit)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        49999979,
-      )
-
-      // 2 weeks pass
-      // Fee should be around 2.5e7
-      await setTimestamp((await getCurrentBlockTimestamp()) + TIME.WEEKS * 2)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        24999979,
-      )
-    })
-
-    it("Increase withdraw fee from 0% to 0.5%, 2 weeks after last deposit", async () => {
-      // User 2 adds liquidity once when fee is 0%
-      await metaSwap
-        .connect(user2)
-        .addLiquidity(
-          [String(1e18), String(1e18)],
-          0,
-          (await getCurrentBlockTimestamp()) + 60,
-        )
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        0,
-      )
-
-      // User 2 adds liquidity again at 2 weeks time
-      let nextTimestamp = (await getCurrentBlockTimestamp()) + TIME.WEEKS * 2
-      await setNextTimestamp(nextTimestamp)
-      await metaSwap
-        .connect(user2)
-        .addLiquidity([String(1e18), String(1e18)], 0, nextTimestamp + 60)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        0,
-      )
-
-      // After 2 weeks since last deposit Fee is updated to 0.5%
-      nextTimestamp = (await getCurrentBlockTimestamp()) + TIME.WEEKS * 2
-      await setNextTimestamp(nextTimestamp)
-      await metaSwap.setDefaultWithdrawFee(String(5e7))
-
-      // Since 2 weeks is already past, fee should linearly decay from 0.25% to 0% over 2 weeks
-      // Fee should start aat 0.25% and decay to 0% linearly over the next 2 weeks
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        25000000,
-      )
-
-      // 2 weeks pass
-      // Fee should be 0
-      await setTimestamp((await getCurrentBlockTimestamp()) + TIME.WEEKS * 2)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        0,
-      )
-    })
-
-    it("Increase withdraw fee from 0% to 0.5%, 4 weeks after last deposit", async () => {
-      // User 2 adds liquidity once when fee is 0%
-      await metaSwap
-        .connect(user2)
-        .addLiquidity(
-          [String(1e18), String(1e18)],
-          0,
-          (await getCurrentBlockTimestamp()) + 60,
-        )
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        0,
-      )
-
-      // User 2 adds liquidity again at 2 weeks time
-      let nextTimestamp = (await getCurrentBlockTimestamp()) + TIME.WEEKS * 2
-      await setNextTimestamp(nextTimestamp)
-      await metaSwap
-        .connect(user2)
-        .addLiquidity([String(1e18), String(1e18)], 0, nextTimestamp + 60)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        0,
-      )
-
-      // After 4 weeks since last deposit, fee is updated to 0.5%
-      nextTimestamp = (await getCurrentBlockTimestamp()) + TIME.WEEKS * 4
-      await setNextTimestamp(nextTimestamp)
-      await metaSwap.setDefaultWithdrawFee(String(5e7))
-
-      // Since 4 weeks is already past since last deposit, fee should be 0.
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        0,
-      )
-    })
-
-    it("Increase withdraw fee from 0.5% to 1%", async () => {
-      await metaSwap.setDefaultWithdrawFee(String(5e7))
-
-      // User 2 adds liquidity once when fee is 0.5%
-      await metaSwap
-        .connect(user2)
-        .addLiquidity(
-          [String(1e18), String(1e18)],
-          0,
-          (await getCurrentBlockTimestamp()) + 60,
-        )
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        50000000,
-      )
-
-      // User 2 adds liquidity again at 2 weeks time
-      // First deposit is discounted to half. Full fee is applied to second deposit
-      // Total withdraw fee should come out to 0.375%
-      // ((1e18 * 0.25%) + (1e18 * 0.5%)) / 2e18 = 0.375%
-      const nextTimestamp = (await getCurrentBlockTimestamp()) + TIME.WEEKS * 2
-      await setNextTimestamp(nextTimestamp)
-      await metaSwap
-        .connect(user2)
-        .addLiquidity([String(1e18), String(1e18)], 0, nextTimestamp + 60)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        37500000,
-      )
-
-      // Fee is updated to 1%
-      // Same math should apply as before but with base fee of 1%
-      // ((1e18 * 0.5%) + (1e18 * 1%)) / 2e18 = 0.75%
-      await metaSwap.setDefaultWithdrawFee(String(1e8))
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        74999968,
-      )
-
-      // 2 weeks pass
-      // Fee should be around 2.5e7
-      await setTimestamp((await getCurrentBlockTimestamp()) + TIME.WEEKS * 2)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        37499968,
-      )
-    })
-
-    it("Decrease withdraw fee from 0.5% to 0%", async () => {
-      await metaSwap.setDefaultWithdrawFee(String(5e7))
-
-      // User 2 adds liquidity once when fee is 0.5%
-      await metaSwap
-        .connect(user2)
-        .addLiquidity(
-          [String(1e18), String(1e18)],
-          0,
-          (await getCurrentBlockTimestamp()) + 60,
-        )
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        50000000,
-      )
-
-      // User 2 adds liquidity again at 2 weeks time
-      // First deposit is discounted to half. Full fee is applied to second deposit
-      // Total withdraw fee should come out to 0.375%
-      // ((1e18 * 0.25%) + (1e18 * 0.5%)) / 2e18 = 0.375%
-      const nextTimestamp = (await getCurrentBlockTimestamp()) + TIME.WEEKS * 2
-      await setNextTimestamp(nextTimestamp)
-      await metaSwap
-        .connect(user2)
-        .addLiquidity([String(1e18), String(1e18)], 0, nextTimestamp + 60)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        37500000,
-      )
-
-      // Fee is updated to 0%
-      await metaSwap.setDefaultWithdrawFee(String(0))
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        0,
-      )
-
-      // 2 weeks pass
-      await setTimestamp((await getCurrentBlockTimestamp()) + TIME.WEEKS * 2)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        0,
-      )
-    })
-
-    it("Decrease withdraw fee from 1% to 0.5%", async () => {
-      await metaSwap.setDefaultWithdrawFee(String(1e8))
-
-      // User 2 adds liquidity once when fee is 1%
-      await metaSwap
-        .connect(user2)
-        .addLiquidity(
-          [String(1e18), String(1e18)],
-          0,
-          (await getCurrentBlockTimestamp()) + 60,
-        )
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        100000000,
-      )
-
-      // User 2 adds liquidity again at 2 weeks time
-      // First deposit is discounted to half. Full fee is applied to second deposit
-      // Total withdraw fee should come out to 0.75%
-      // ((1e18 * 0.5%) + (1e18 * 1%)) / 2e18 = 0.75%
-      const nextTimestamp = (await getCurrentBlockTimestamp()) + TIME.WEEKS * 2
-      await setNextTimestamp(nextTimestamp)
-      await metaSwap
-        .connect(user2)
-        .addLiquidity([String(1e18), String(1e18)], 0, nextTimestamp + 60)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        75000000,
-      )
-
-      // Fee is decreased to 0.5%
-      // Fee should decrease by half
-      await metaSwap.setDefaultWithdrawFee(String(5e7))
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        37499984,
-      )
-
-      // 2 weeks pass
-      await setTimestamp((await getCurrentBlockTimestamp()) + TIME.WEEKS * 2)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        18749984,
-      )
-
-      // 2 weeks pass. This is 4 weeks mark since last deposit. Fee should be 0.
-      await setTimestamp((await getCurrentBlockTimestamp()) + TIME.WEEKS * 2)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        0,
-      )
-    })
-  })
-
-  describe("updateUserWithdrawFee", async () => {
-    it("Reverts with 'Only callable by pool token'", async () => {
-      await expect(
-        metaSwap
-          .connect(user1)
-          .updateUserWithdrawFee(ZERO_ADDRESS, String(5e7)),
-      ).to.be.revertedWith("Only callable by pool token")
-    })
-
-    it("Test adding liquidity, and once again at 2 weeks mark then removing all deposits at 4 weeks mark", async () => {
-      await metaSwap.setDefaultWithdrawFee(String(5e7))
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(1e18), String(1e18)], 0, MAX_UINT256)
-      const depositTimestamp = (
-        await metaSwap.getDepositTimestamp(user1Address)
-      ).toNumber()
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(5e7),
-      )
-
-      // 2 weeks after
-      await setNextTimestamp(depositTimestamp + 2 * TIME.WEEKS)
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(2e18), String(2e18)], 0, MAX_UINT256)
-
-      // At 2 weeks mark, half of first deposit's withdrawal fee is discounted, 0.25%.
-      // We are adding twice the amount of first deposit at full withdrawal fee amount, 0.5%.
-      // Remainder of the fees + new fees is then again stretched out to be discounted over the decay period (4 weeks)
-      // (2e18 * 0.25% + 4e18 * 0.5%) / 6e18 = 0.41666666%
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from("41666666"),
-      )
-
-      await metaLPToken
-        .connect(user1)
-        .approve(metaSwap.address, await metaLPToken.balanceOf(user1Address))
-
-      const [firstBalanceBefore, secondBalanceBefore] =
-        await getUserTokenBalances(user1, [susd, baseLPToken])
-      const currentPoolTokenBalance = await metaLPToken.balanceOf(user1Address)
-
-      // 4 weeks after initial deposit
-      await setNextTimestamp(depositTimestamp + 4 * TIME.WEEKS)
-      await metaSwap
-        .connect(user1)
-        .removeLiquidity(currentPoolTokenBalance, [0, 0], MAX_UINT256)
-
-      const [firstBalanceAfter, secondBalanceAfter] =
-        await getUserTokenBalances(user1, [susd, baseLPToken])
-
-      // Returned amounts are (100 - 0.41666666 / 2) = 99.79166667% of total deposits
-      // 3e18 * 99.79166667% = 2.9937500001e18
-      expect(firstBalanceAfter.sub(firstBalanceBefore)).to.eq(
-        "2993750000100000000",
-      )
-      expect(secondBalanceAfter.sub(secondBalanceBefore)).to.eq(
-        "2993750000100000000",
-      )
-    })
-
-    it("Verify withdraw fees are updated on transfer", async () => {
-      await metaSwap.setDefaultWithdrawFee(String(5e7))
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(1e18), String(1e18)], 0, MAX_UINT256)
-      const depositTimestamp = (
-        await metaSwap.getDepositTimestamp(user1Address)
-      ).toNumber()
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(5e7),
-      )
-
-      // 2 weeks after
-      await setNextTimestamp(depositTimestamp + 2 * TIME.WEEKS)
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(2e18), String(2e18)], 0, MAX_UINT256)
-
-      // At 2 weeks mark, half of first deposit's withdrawal fee is discounted, 0.25%.
-      // We are adding twice the amount of first deposit at full withdrawal fee amount, 0.5%.
-      // Remainder of the fees + new fees is then again stretched out to be discounted over the decay period (4 weeks)
-      // (2e18 * 0.25% + 4e18 * 0.5%) / 6e18 = 0.41666666%
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from("41666666"),
-      )
-
-      // Transfer some of swap token from user1 to user2
-      await metaLPToken.connect(user1).transfer(user2Address, String(1e18))
-
-      // Verify user1's fee has not changed
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from("41666649"),
-      )
-
-      // Verify user2's fee is set to default value
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.eq(
-        BigNumber.from("50000000"),
-      )
-
-      await setTimestamp((await getCurrentBlockTimestamp()) + 2 * TIME.WEEKS)
-
-      // Verify user2's fee decays as expected
-      let currentFee = await metaSwap.calculateCurrentWithdrawFee(user2Address)
-      expect(currentFee).to.lte(BigNumber.from("25000000"))
-      expect(currentFee).to.gte(BigNumber.from("24993778"))
-
-      // Transfer more tokens to user2
-      await metaLPToken.connect(user1).transfer(user2Address, String(1e18))
-
-      // Verify user2's fee has updated with discounted rate
-      currentFee = await metaSwap.calculateCurrentWithdrawFee(user2Address)
-      expect(currentFee).to.lte(BigNumber.from("37499989"))
-      expect(currentFee).to.gte(BigNumber.from("37497044"))
-    })
-  })
-
-  describe("setDefaultWithdrawFee", () => {
-    it("Emits NewWithdrawFee event", async () => {
-      await expect(metaSwap.setDefaultWithdrawFee(String(5e7))).to.emit(
-        metaSwap,
-        "NewWithdrawFee",
-      )
-    })
-
-    it("Setting the withdraw fee affects past deposits as well", async () => {
-      await metaSwap.setDefaultWithdrawFee(String(5e7))
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(1e18), String(1e18)], 0, MAX_UINT256)
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(5e7),
-      )
-
-      await metaSwap.setDefaultWithdrawFee(String(0))
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(0),
-      )
-    })
-
-    it("Reverts when fee is too high", async () => {
-      await expect(metaSwap.setDefaultWithdrawFee(String(15e8))).to.be.reverted
     })
   })
 

--- a/test/metaSwapDecimals.ts
+++ b/test/metaSwapDecimals.ts
@@ -167,7 +167,6 @@ describe("Meta-Swap", async () => {
         INITIAL_A_VALUE,
         SWAP_FEE,
         0,
-        0,
         (
           await get("LPToken")
         ).address,
@@ -299,11 +298,7 @@ describe("Meta-Swap", async () => {
       await expect(
         metaSwap
           .connect(user1)
-          .calculateTokenAmount(
-            user1Address,
-            [MAX_UINT256, String(3e18)],
-            false,
-          ),
+          .calculateTokenAmount([MAX_UINT256, String(3e18)], false),
       ).to.be.revertedWith("Cannot withdraw more than available")
     })
 
@@ -320,7 +315,7 @@ describe("Meta-Swap", async () => {
     it("Succeeds with expected output amount of pool tokens", async () => {
       const calculatedPoolTokenAmount = await metaSwap
         .connect(user1)
-        .calculateTokenAmount(user1Address, [String(1e6), String(3e18)], true)
+        .calculateTokenAmount([String(1e6), String(3e18)], true)
 
       const calculatedPoolTokenAmountWithSlippage = calculatedPoolTokenAmount
         .mul(999)
@@ -343,7 +338,7 @@ describe("Meta-Swap", async () => {
     it("Succeeds with actual pool token amount being within ±0.1% range of calculated pool token", async () => {
       const calculatedPoolTokenAmount = await metaSwap
         .connect(user1)
-        .calculateTokenAmount(user1Address, [String(1e6), String(3e18)], true)
+        .calculateTokenAmount([String(1e6), String(3e18)], true)
 
       const calculatedPoolTokenAmountWithNegativeSlippage =
         calculatedPoolTokenAmount.mul(999).div(1000)
@@ -395,7 +390,7 @@ describe("Meta-Swap", async () => {
     it("Reverts when minToMint is not reached due to front running", async () => {
       const calculatedLPTokenAmount = await metaSwap
         .connect(user1)
-        .calculateTokenAmount(user1Address, [String(1e6), String(3e18)], true)
+        .calculateTokenAmount([String(1e6), String(3e18)], true)
 
       const calculatedLPTokenAmountWithSlippage = calculatedLPTokenAmount
         .mul(999)
@@ -433,7 +428,7 @@ describe("Meta-Swap", async () => {
     it("Emits addLiquidity event", async () => {
       const calculatedLPTokenAmount = await metaSwap
         .connect(user1)
-        .calculateTokenAmount(user1Address, [String(2e6), String(1e16)], true)
+        .calculateTokenAmount([String(2e6), String(1e16)], true)
 
       const calculatedLPTokenAmountWithSlippage = calculatedLPTokenAmount
         .mul(999)
@@ -454,7 +449,7 @@ describe("Meta-Swap", async () => {
   describe("removeLiquidity", () => {
     it("Reverts with 'Cannot exceed total supply'", async () => {
       await expect(
-        metaSwap.calculateRemoveLiquidity(ZERO_ADDRESS, MAX_UINT256),
+        metaSwap.calculateRemoveLiquidity(MAX_UINT256),
       ).to.be.revertedWith("Cannot exceed total supply")
     })
 
@@ -508,10 +503,7 @@ describe("Meta-Swap", async () => {
       )
 
       const [expectedFirstTokenAmount, expectedSecondTokenAmount] =
-        await metaSwap.calculateRemoveLiquidity(
-          user1Address,
-          poolTokenBalanceBefore,
-        )
+        await metaSwap.calculateRemoveLiquidity(poolTokenBalanceBefore)
 
       expect(expectedFirstTokenAmount).to.eq(BigNumber.from("1498602"))
       expect(expectedSecondTokenAmount).to.eq(
@@ -584,10 +576,7 @@ describe("Meta-Swap", async () => {
       expect(currentUser1Balance).to.eq(BigNumber.from("1996275943410518065"))
 
       const [expectedFirstTokenAmount, expectedSecondTokenAmount] =
-        await metaSwap.calculateRemoveLiquidity(
-          user1Address,
-          currentUser1Balance,
-        )
+        await metaSwap.calculateRemoveLiquidity(currentUser1Balance)
 
       expect(expectedFirstTokenAmount).to.eq(BigNumber.from("1498602"))
       expect(expectedSecondTokenAmount).to.eq(
@@ -723,7 +712,6 @@ describe("Meta-Swap", async () => {
 
       // User 1 calculates amount of pool token to be burned
       const maxPoolTokenAmountToBeBurned = await metaSwap.calculateTokenAmount(
-        user1Address,
         [String(1e6), String(1e16)],
         false,
       )
@@ -838,7 +826,6 @@ describe("Meta-Swap", async () => {
 
       // User 1 calculates amount of pool token to be burned
       const maxPoolTokenAmountToBeBurned = await metaSwap.calculateTokenAmount(
-        user1Address,
         [String(1e6), String(1e16)],
         false,
       )
@@ -942,7 +929,7 @@ describe("Meta-Swap", async () => {
 
     it("Reverts with 'Token index out of range'", async () => {
       await expect(
-        metaSwap.calculateRemoveLiquidityOneToken(ZERO_ADDRESS, 1, 5),
+        metaSwap.calculateRemoveLiquidityOneToken(1, 5),
       ).to.be.revertedWith("Token index out of range")
     })
 
@@ -956,7 +943,6 @@ describe("Meta-Swap", async () => {
 
       await expect(
         metaSwap.calculateRemoveLiquidityOneToken(
-          user1Address,
           currentUser1Balance.mul(2),
           0,
         ),
@@ -979,11 +965,7 @@ describe("Meta-Swap", async () => {
 
       // User 1 calculates the amount of underlying token to receive.
       const calculatedFirstTokenAmount =
-        await metaSwap.calculateRemoveLiquidityOneToken(
-          user1Address,
-          currentUser1Balance,
-          0,
-        )
+        await metaSwap.calculateRemoveLiquidityOneToken(currentUser1Balance, 0)
       expect(calculatedFirstTokenAmount).to.eq(BigNumber.from("2008990"))
 
       // User 1 initiates one token withdrawal
@@ -1044,11 +1026,7 @@ describe("Meta-Swap", async () => {
 
       // User 1 calculates the amount of underlying token to receive.
       const calculatedFirstTokenAmount =
-        await metaSwap.calculateRemoveLiquidityOneToken(
-          user1Address,
-          currentUser1Balance,
-          0,
-        )
+        await metaSwap.calculateRemoveLiquidityOneToken(currentUser1Balance, 0)
       expect(calculatedFirstTokenAmount).to.eq(BigNumber.from("2008990"))
 
       // User 2 adds liquidity before User 1 initiates withdrawal
@@ -1818,923 +1796,6 @@ describe("Meta-Swap", async () => {
       expect(secondTokenAfter.sub(secondTokenBefore)).to.eq(
         BigNumber.from("1000981001788791742"),
       )
-    })
-  })
-
-  describe("Test withdrawal fees on removeLiquidity", () => {
-    beforeEach(async () => {
-      expect(await metaLPToken.balanceOf(user1Address)).to.eq(0)
-      await metaSwap.setDefaultWithdrawFee(String(5e7))
-      await metaLPToken.connect(user1).approve(metaSwap.address, MAX_UINT256)
-    })
-
-    it("Removing liquidity immediately after deposit", async () => {
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(1e6), String(1e18)], 0, MAX_UINT256)
-
-      const currentPoolTokenBalance = await metaLPToken.balanceOf(user1Address)
-
-      const depositTimestamp = (
-        await metaSwap.getDepositTimestamp(user1Address)
-      ).toNumber()
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(5e7),
-      )
-
-      const expectedTokenAmounts = await metaSwap.calculateRemoveLiquidity(
-        user1Address,
-        currentPoolTokenBalance,
-      )
-      expect(expectedTokenAmounts[0]).to.eq("995000")
-      expect(expectedTokenAmounts[1]).to.eq("995000000000000000")
-
-      const expectedTokenAmountsWithoutWithdrawalFee =
-        await metaSwap.calculateRemoveLiquidity(
-          ZERO_ADDRESS,
-          currentPoolTokenBalance,
-        )
-      expect(expectedTokenAmountsWithoutWithdrawalFee[0]).to.eq(String(1e6))
-      expect(expectedTokenAmountsWithoutWithdrawalFee[1]).to.eq(String(1e18))
-
-      const [firstBalanceBefore, secondBalanceBefore] =
-        await getUserTokenBalances(user1, [dummyUSD, baseLPToken])
-
-      // Manually set the timestamp between addLiquidity and removeLiquidity to 1 second
-      await setNextTimestamp(depositTimestamp + 1)
-      await metaSwap
-        .connect(user1)
-        .removeLiquidity(currentPoolTokenBalance, [0, 0], MAX_UINT256)
-
-      const [firstBalanceAfter, secondBalanceAfter] =
-        await getUserTokenBalances(user1, [dummyUSD, baseLPToken])
-
-      // Returned amounts are about 99.5% of initial deposits
-      expect(firstBalanceAfter.sub(firstBalanceBefore)).to.eq("995000")
-      expect(secondBalanceAfter.sub(secondBalanceBefore)).to.eq(
-        "995000002100000000",
-      )
-    })
-
-    it("Removing liquidity 2 weeks after deposit", async () => {
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(1e6), String(1e18)], 0, MAX_UINT256)
-
-      const depositTimestamp = (
-        await metaSwap.getDepositTimestamp(user1Address)
-      ).toNumber()
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(5e7),
-      )
-
-      const [firstBalanceBefore, secondBalanceBefore] =
-        await getUserTokenBalances(user1, [dummyUSD, baseLPToken])
-      const currentPoolTokenBalance = await metaLPToken.balanceOf(user1Address)
-
-      // 2 weeks = 2 * 604800 seconds
-      await setTimestamp(depositTimestamp + 2 * TIME.WEEKS - 1)
-
-      const expectedTokenAmounts = await metaSwap.calculateRemoveLiquidity(
-        user1Address,
-        currentPoolTokenBalance,
-      )
-      expect(expectedTokenAmounts[0]).to.eq("997499")
-      expect(expectedTokenAmounts[1]).to.eq("997499998000000000")
-
-      const expectedTokenAmountsWithoutWithdrawalFee =
-        await metaSwap.calculateRemoveLiquidity(
-          ZERO_ADDRESS,
-          currentPoolTokenBalance,
-        )
-      expect(expectedTokenAmountsWithoutWithdrawalFee[0]).to.eq(String(1e6))
-      expect(expectedTokenAmountsWithoutWithdrawalFee[1]).to.eq(String(1e18))
-
-      await setNextTimestamp(depositTimestamp + 2 * TIME.WEEKS)
-      await metaSwap
-        .connect(user1)
-        .removeLiquidity(currentPoolTokenBalance, [0, 0], MAX_UINT256)
-
-      const [firstBalanceAfter, secondBalanceAfter] =
-        await getUserTokenBalances(user1, [dummyUSD, baseLPToken])
-
-      // Returned amounts are 99.75% of initial deposits
-      expect(firstBalanceAfter.sub(firstBalanceBefore)).to.eq("997500")
-      expect(secondBalanceAfter.sub(secondBalanceBefore)).to.eq(
-        "997500000000000000",
-      )
-    })
-
-    it("Removing liquidity 4 weeks after deposit", async () => {
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(1e6), String(1e18)], 0, MAX_UINT256)
-
-      const depositTimestamp = (
-        await metaSwap.getDepositTimestamp(user1Address)
-      ).toNumber()
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(5e7),
-      )
-
-      const [firstBalanceBefore, secondBalanceBefore] =
-        await getUserTokenBalances(user1, [dummyUSD, baseLPToken])
-
-      const currentPoolTokenBalance = await metaLPToken.balanceOf(user1Address)
-
-      // 4 weeks = 4 * 604800 seconds
-      await setTimestamp(depositTimestamp + 4 * TIME.WEEKS)
-      const expectedTokenAmounts = await metaSwap.calculateRemoveLiquidity(
-        user1Address,
-        currentPoolTokenBalance,
-      )
-      expect(expectedTokenAmounts[0]).to.eq(String(1e6))
-      expect(expectedTokenAmounts[1]).to.eq(String(1e18))
-
-      const expectedTokenAmountsWithoutWithdrawalFee =
-        await metaSwap.calculateRemoveLiquidity(
-          ZERO_ADDRESS,
-          currentPoolTokenBalance,
-        )
-      expect(expectedTokenAmountsWithoutWithdrawalFee[0]).to.eq(String(1e6))
-      expect(expectedTokenAmountsWithoutWithdrawalFee[1]).to.eq(String(1e18))
-
-      await metaSwap
-        .connect(user1)
-        .removeLiquidity(currentPoolTokenBalance, [0, 0], MAX_UINT256)
-
-      const [firstBalanceAfter, secondBalanceAfter] =
-        await getUserTokenBalances(user1, [dummyUSD, baseLPToken])
-
-      // Returned amounts are 100% of initial deposits
-      expect(firstBalanceAfter.sub(firstBalanceBefore)).to.eq("1000000")
-      expect(secondBalanceAfter.sub(secondBalanceBefore)).to.eq(
-        "1000000000000000000",
-      )
-    })
-  })
-
-  describe("Test withdrawal fees on removeLiquidityOne", async () => {
-    beforeEach(async () => {
-      await metaLPToken.approve(metaSwap.address, MAX_UINT256)
-      await metaSwap.removeLiquidity(
-        await metaLPToken.balanceOf(ownerAddress),
-        [0, 0],
-        MAX_UINT256,
-      )
-      expect(await metaLPToken.totalSupply()).to.eq(0)
-      await metaSwap.setDefaultWithdrawFee(String(5e7))
-
-      // reset the pool
-      await metaSwap.addLiquidity([String(1e7), String(1e19)], 0, MAX_UINT256)
-      await metaLPToken.connect(user1).approve(metaSwap.address, MAX_UINT256)
-    })
-
-    it("Removing liquidity immediately after deposit", async () => {
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(1e6), String(1e18)], 0, MAX_UINT256)
-      const depositTimestamp = (
-        await metaSwap.getDepositTimestamp(user1Address)
-      ).toNumber()
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(5e7),
-      )
-
-      const firstBalanceBefore = await getUserTokenBalance(user1, dummyUSD)
-      const swapTokenBalance = await getUserTokenBalance(user1, metaLPToken)
-
-      const expectedFirstTokenAmount =
-        await metaSwap.calculateRemoveLiquidityOneToken(
-          user1Address,
-          swapTokenBalance,
-          0,
-        )
-      expect(expectedFirstTokenAmount).to.eq("1987041")
-
-      const expectedFirstTokenAmountWithoutWithdrawalFee =
-        await metaSwap.calculateRemoveLiquidityOneToken(
-          ZERO_ADDRESS,
-          swapTokenBalance,
-          0,
-        )
-      expect(expectedFirstTokenAmountWithoutWithdrawalFee).to.eq("1997027")
-
-      await setNextTimestamp(depositTimestamp + 1)
-      await metaSwap
-        .connect(user1)
-        .removeLiquidityOneToken(swapTokenBalance, 0, 0, MAX_UINT256)
-
-      const firstBalanceAfter = await getUserTokenBalance(user1, dummyUSD)
-
-      expect(firstBalanceAfter.sub(firstBalanceBefore)).to.eq("1987041")
-    })
-
-    it("Removing liquidity 2 weeks after deposit", async () => {
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(1e6), String(1e18)], 0, MAX_UINT256)
-      const depositTimestamp = (
-        await metaSwap.getDepositTimestamp(user1Address)
-      ).toNumber()
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(5e7),
-      )
-
-      const [firstBalanceBefore, swapTokenBalance] = await getUserTokenBalances(
-        user1,
-        [dummyUSD, metaLPToken],
-      )
-
-      const initiallyExpectedFirstTokenAmount =
-        await metaSwap.calculateRemoveLiquidityOneToken(
-          user1Address,
-          swapTokenBalance,
-          0,
-        )
-      expect(initiallyExpectedFirstTokenAmount).to.eq("1987041")
-
-      const expectedFirstTokenAmountWithoutWithdrawalFee =
-        await metaSwap.calculateRemoveLiquidityOneToken(
-          ZERO_ADDRESS,
-          swapTokenBalance,
-          0,
-        )
-      expect(expectedFirstTokenAmountWithoutWithdrawalFee).to.eq("1997027")
-
-      await setTimestamp(depositTimestamp + 2 * TIME.WEEKS - 1)
-
-      const expectedFirstTokenAmount =
-        await metaSwap.calculateRemoveLiquidityOneToken(
-          user1Address,
-          swapTokenBalance,
-          0,
-        )
-      expect(expectedFirstTokenAmount).to.eq("1992034")
-
-      await setNextTimestamp(depositTimestamp + 2 * TIME.WEEKS)
-
-      await metaSwap
-        .connect(user1)
-        .removeLiquidityOneToken(swapTokenBalance, 0, 0, MAX_UINT256)
-
-      const firstBalanceAfter = await getUserTokenBalance(user1, dummyUSD)
-
-      expect(firstBalanceAfter.sub(firstBalanceBefore)).to.eq("1992034")
-    })
-
-    it("Removing liquidity 4 weeks after deposit", async () => {
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(1e6), String(1e18)], 0, MAX_UINT256)
-      const depositTimestamp = (
-        await metaSwap.getDepositTimestamp(user1Address)
-      ).toNumber()
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(5e7),
-      )
-
-      const [firstBalanceBefore, swapTokenBalance] = await getUserTokenBalances(
-        user1,
-        [dummyUSD, metaLPToken],
-      )
-
-      const initiallyExpectedFirstTokenAmount =
-        await metaSwap.calculateRemoveLiquidityOneToken(
-          user1Address,
-          swapTokenBalance,
-          0,
-        )
-      expect(initiallyExpectedFirstTokenAmount).to.eq("1987041")
-
-      const expectedFirstTokenAmountWithoutWithdrawalFee =
-        await metaSwap.calculateRemoveLiquidityOneToken(
-          ZERO_ADDRESS,
-          swapTokenBalance,
-          0,
-        )
-      expect(expectedFirstTokenAmountWithoutWithdrawalFee).to.eq("1997027")
-
-      await setTimestamp(depositTimestamp + 4 * TIME.WEEKS)
-
-      const expectedFirstTokenAmount =
-        await metaSwap.calculateRemoveLiquidityOneToken(
-          user1Address,
-          swapTokenBalance,
-          0,
-        )
-      expect(expectedFirstTokenAmount).to.eq("1997027")
-
-      await metaSwap
-        .connect(user1)
-        .removeLiquidityOneToken(swapTokenBalance, 0, 0, MAX_UINT256)
-
-      const firstBalanceAfter = await getUserTokenBalance(user1, dummyUSD)
-
-      // 1997027 * 100%
-      expect(firstBalanceAfter.sub(firstBalanceBefore)).to.eq("1997027")
-    })
-  })
-
-  describe("Test withdrawal fees on removeLiquidityImbalance", async () => {
-    beforeEach(async () => {
-      await metaLPToken.approve(metaSwap.address, MAX_UINT256)
-      await metaSwap.removeLiquidity(
-        await metaLPToken.balanceOf(ownerAddress),
-        [0, 0],
-        MAX_UINT256,
-      )
-      expect(await metaLPToken.totalSupply()).to.eq(0)
-      await metaSwap.setDefaultWithdrawFee(String(5e7))
-
-      // reset the pool
-      await metaSwap.addLiquidity([String(1e7), String(1e19)], 0, MAX_UINT256)
-      await metaLPToken.connect(user1).approve(metaSwap.address, MAX_UINT256)
-    })
-
-    it("Removing liquidity immediately after deposit", async () => {
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(1e6), String(1e18)], 0, MAX_UINT256)
-      const depositTimestamp = (
-        await metaSwap.getDepositTimestamp(user1Address)
-      ).toNumber()
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(5e7),
-      )
-
-      const [firstTokenBefore, secondTokenBefore, swapTokenBefore] =
-        await getUserTokenBalances(user1, [dummyUSD, baseLPToken, metaLPToken])
-
-      const expectedBurnAmount = await metaSwap.calculateTokenAmount(
-        user1Address,
-        [String(1e6), String(1e17)],
-        false,
-      )
-      expect(expectedBurnAmount).to.eq("1105910196876519474")
-
-      const expectedBurnAmountWithoutWithdrawalFee =
-        await metaSwap.calculateTokenAmount(
-          ZERO_ADDRESS,
-          [String(1e6), String(1e17)],
-          false,
-        )
-      expect(expectedBurnAmountWithoutWithdrawalFee).to.eq(
-        "1100380645892136877",
-      )
-
-      await setNextTimestamp(depositTimestamp + 1)
-      await metaSwap
-        .connect(user1)
-        .removeLiquidityImbalance(
-          [String(1e6), String(1e17)],
-          swapTokenBefore,
-          MAX_UINT256,
-        )
-
-      const [firstTokenAfter, secondTokenAfter, swapTokenAfter] =
-        await getUserTokenBalances(user1, [dummyUSD, baseLPToken, metaLPToken])
-
-      expect(firstTokenAfter.sub(firstTokenBefore)).to.eq(String(1e6))
-      expect(secondTokenAfter.sub(secondTokenBefore)).to.eq(String(1e17))
-
-      // Below comparison with defaultWithdrawFee set to zero results in 1100830653956319289
-      // Total amount of burned token should be close to
-      // 1100830653956319289 / 0.995
-
-      // Actual amount burned / expected amount burned = 1.00040895461
-      expect(swapTokenBefore.sub(swapTokenAfter)).to.eq("1106361553780012310")
-    })
-
-    it("Removing liquidity 2 weeks after deposit", async () => {
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(1e6), String(1e18)], 0, MAX_UINT256)
-      const depositTimestamp = (
-        await metaSwap.getDepositTimestamp(user1Address)
-      ).toNumber()
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(5e7),
-      )
-
-      const [firstTokenBefore, secondTokenBefore, swapTokenBefore] =
-        await getUserTokenBalances(user1, [dummyUSD, baseLPToken, metaLPToken])
-
-      await setTimestamp(depositTimestamp + 2 * TIME.WEEKS - 1)
-
-      const expectedBurnAmount = await metaSwap.calculateTokenAmount(
-        user1Address,
-        [String(1e6), String(1e17)],
-        false,
-      )
-      expect(expectedBurnAmount).to.eq("1103138494334249489")
-
-      const expectedBurnAmountWithoutWithdrawalFee =
-        await metaSwap.calculateTokenAmount(
-          ZERO_ADDRESS,
-          [String(1e6), String(1e17)],
-          false,
-        )
-      expect(expectedBurnAmountWithoutWithdrawalFee).to.eq(
-        "1100380645892136877",
-      )
-
-      await setNextTimestamp(depositTimestamp + 2 * TIME.WEEKS)
-      await metaSwap
-        .connect(user1)
-        .removeLiquidityImbalance(
-          [String(1e6), String(1e17)],
-          swapTokenBefore,
-          MAX_UINT256,
-        )
-
-      const [firstTokenAfter, secondTokenAfter, swapTokenAfter] =
-        await getUserTokenBalances(user1, [dummyUSD, baseLPToken, metaLPToken])
-
-      expect(firstTokenAfter.sub(firstTokenBefore)).to.eq(String(1e6))
-      expect(secondTokenAfter.sub(secondTokenBefore)).to.eq(String(1e17))
-
-      // 1100830653956319289 / 0.9975 = 1103589628026385252
-      // Actual amount burned / expected amount burned = 1.00040895472
-      expect(swapTokenBefore.sub(swapTokenAfter)).to.eq("1103588720134808533")
-    })
-
-    it("Removing liquidity 4 weeks after deposit", async () => {
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(1e6), String(1e18)], 0, MAX_UINT256)
-      const depositTimestamp = (
-        await metaSwap.getDepositTimestamp(user1Address)
-      ).toNumber()
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(5e7),
-      )
-
-      const [firstTokenBefore, secondTokenBefore, swapTokenBefore] =
-        await getUserTokenBalances(user1, [dummyUSD, baseLPToken, metaLPToken])
-
-      await setTimestamp(depositTimestamp + 4 * TIME.WEEKS)
-
-      const expectedBurnAmount = await metaSwap.calculateTokenAmount(
-        user1Address,
-        [String(1e6), String(1e17)],
-        false,
-      )
-      expect(expectedBurnAmount).to.eq("1100380645892136877")
-
-      const expectedBurnAmountWithoutWithdrawalFee =
-        await metaSwap.calculateTokenAmount(
-          ZERO_ADDRESS,
-          [String(1e6), String(1e17)],
-          false,
-        )
-      expect(expectedBurnAmountWithoutWithdrawalFee).to.eq(
-        "1100380645892136877",
-      )
-
-      await metaSwap
-        .connect(user1)
-        .removeLiquidityImbalance(
-          [String(1e6), String(1e17)],
-          swapTokenBefore,
-          MAX_UINT256,
-        )
-
-      const [firstTokenAfter, secondTokenAfter, swapTokenAfter] =
-        await getUserTokenBalances(user1, [dummyUSD, baseLPToken, metaLPToken])
-
-      expect(firstTokenAfter.sub(firstTokenBefore)).to.eq(String(1e6))
-      expect(secondTokenAfter.sub(secondTokenBefore)).to.eq(String(1e17))
-
-      // 1100829748334471512 / 1.0000 = 1100829748334471512
-      // Actual amount burned / expected amount burned = 1.00040813372
-      expect(swapTokenBefore.sub(swapTokenAfter)).to.eq("1100829748334471512")
-    })
-  })
-
-  describe("Verify changing withdraw fee works as expected", async () => {
-    // This test ensures that changing withdraw fee impacts deposits made in the past
-    //
-    // [Cases when withdraw fee is increased]
-    // - When fee is increased from 0
-    // Current balance and last deposit time is used for fee calculation.
-    // Therefore the fee decays from full amount since the last deposit.
-    // If the last deposit was more than 4 weeks prior to the fee increase, fee should be 0.
-    //
-    // - When fee is increased from x% to y%, where x > 0
-    // Discounts from past deposits should apply accordingly and total fee should increase by rate of (y/x).
-    //
-    // [Cases when withdraw fee is decreased]
-    // - When fee is decreased to 0
-    // Fee should be 0 regardless when the user last deposited.
-    //
-    // - When fee is decreased from x% to y%, where y > 0
-    // Discounts from past deposits should apply accordingly and total fee should decrease by rate of (y/x).
-
-    it("Increase withdraw fee from 0% to 0.5%, immediately after last deposit", async () => {
-      // User 2 adds liquidity once when fee is 0%
-      await metaSwap
-        .connect(user2)
-        .addLiquidity(
-          [String(1e6), String(1e18)],
-          0,
-          (await getCurrentBlockTimestamp()) + 60,
-        )
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        0,
-      )
-
-      // User 2 adds liquidity again at 2 weeks time
-      const nextTimestamp = (await getCurrentBlockTimestamp()) + TIME.WEEKS * 2
-      await setNextTimestamp(nextTimestamp)
-      await metaSwap
-        .connect(user2)
-        .addLiquidity([String(1e6), String(1e18)], 0, nextTimestamp + 60)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        0,
-      )
-
-      // Fee is updated to 0.5%
-      await metaSwap.setDefaultWithdrawFee(String(5e7))
-
-      // Fee should linearly decay from 0.5% to 0% since the last deposit
-      // (Fee is bit less than 0.5% because `swap.setDefaultWithdrawFee` is called one block after the last deposit)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        49999979,
-      )
-
-      // 2 weeks pass
-      // Fee should be around 2.5e7
-      await setTimestamp((await getCurrentBlockTimestamp()) + TIME.WEEKS * 2)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        24999979,
-      )
-    })
-
-    it("Increase withdraw fee from 0% to 0.5%, 2 weeks after last deposit", async () => {
-      // User 2 adds liquidity once when fee is 0%
-      await metaSwap
-        .connect(user2)
-        .addLiquidity(
-          [String(1e6), String(1e18)],
-          0,
-          (await getCurrentBlockTimestamp()) + 60,
-        )
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        0,
-      )
-
-      // User 2 adds liquidity again at 2 weeks time
-      let nextTimestamp = (await getCurrentBlockTimestamp()) + TIME.WEEKS * 2
-      await setNextTimestamp(nextTimestamp)
-      await metaSwap
-        .connect(user2)
-        .addLiquidity([String(1e6), String(1e18)], 0, nextTimestamp + 60)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        0,
-      )
-
-      // After 2 weeks since last deposit Fee is updated to 0.5%
-      nextTimestamp = (await getCurrentBlockTimestamp()) + TIME.WEEKS * 2
-      await setNextTimestamp(nextTimestamp)
-      await metaSwap.setDefaultWithdrawFee(String(5e7))
-
-      // Since 2 weeks is already past, fee should linearly decay from 0.25% to 0% over 2 weeks
-      // Fee should start aat 0.25% and decay to 0% linearly over the next 2 weeks
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        25000000,
-      )
-
-      // 2 weeks pass
-      // Fee should be 0
-      await setTimestamp((await getCurrentBlockTimestamp()) + TIME.WEEKS * 2)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        0,
-      )
-    })
-
-    it("Increase withdraw fee from 0% to 0.5%, 4 weeks after last deposit", async () => {
-      // User 2 adds liquidity once when fee is 0%
-      await metaSwap
-        .connect(user2)
-        .addLiquidity(
-          [String(1e6), String(1e18)],
-          0,
-          (await getCurrentBlockTimestamp()) + 60,
-        )
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        0,
-      )
-
-      // User 2 adds liquidity again at 2 weeks time
-      let nextTimestamp = (await getCurrentBlockTimestamp()) + TIME.WEEKS * 2
-      await setNextTimestamp(nextTimestamp)
-      await metaSwap
-        .connect(user2)
-        .addLiquidity([String(1e6), String(1e18)], 0, nextTimestamp + 60)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        0,
-      )
-
-      // After 4 weeks since last deposit, fee is updated to 0.5%
-      nextTimestamp = (await getCurrentBlockTimestamp()) + TIME.WEEKS * 4
-      await setNextTimestamp(nextTimestamp)
-      await metaSwap.setDefaultWithdrawFee(String(5e7))
-
-      // Since 4 weeks is already past since last deposit, fee should be 0.
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        0,
-      )
-    })
-
-    it("Increase withdraw fee from 0.5% to 1%", async () => {
-      await metaSwap.setDefaultWithdrawFee(String(5e7))
-
-      // User 2 adds liquidity once when fee is 0.5%
-      await metaSwap
-        .connect(user2)
-        .addLiquidity(
-          [String(1e6), String(1e18)],
-          0,
-          (await getCurrentBlockTimestamp()) + 60,
-        )
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        50000000,
-      )
-
-      // User 2 adds liquidity again at 2 weeks time
-      // First deposit is discounted to half. Full fee is applied to second deposit
-      // Total withdraw fee should come out to 0.375%
-      // ((1e18 * 0.25%) + (1e18 * 0.5%)) / 2e18 = 0.375%
-      const nextTimestamp = (await getCurrentBlockTimestamp()) + TIME.WEEKS * 2
-      await setNextTimestamp(nextTimestamp)
-      await metaSwap
-        .connect(user2)
-        .addLiquidity([String(1e6), String(1e18)], 0, nextTimestamp + 60)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        37500000,
-      )
-
-      // Fee is updated to 1%
-      // Same math should apply as before but with base fee of 1%
-      // ((1e18 * 0.5%) + (1e18 * 1%)) / 2e18 = 0.75%
-      await metaSwap.setDefaultWithdrawFee(String(1e8))
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        74999968,
-      )
-
-      // 2 weeks pass
-      // Fee should be around 2.5e7
-      await setTimestamp((await getCurrentBlockTimestamp()) + TIME.WEEKS * 2)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        37499968,
-      )
-    })
-
-    it("Decrease withdraw fee from 0.5% to 0%", async () => {
-      await metaSwap.setDefaultWithdrawFee(String(5e7))
-
-      // User 2 adds liquidity once when fee is 0.5%
-      await metaSwap
-        .connect(user2)
-        .addLiquidity(
-          [String(1e6), String(1e18)],
-          0,
-          (await getCurrentBlockTimestamp()) + 60,
-        )
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        50000000,
-      )
-
-      // User 2 adds liquidity again at 2 weeks time
-      // First deposit is discounted to half. Full fee is applied to second deposit
-      // Total withdraw fee should come out to 0.375%
-      // ((1e18 * 0.25%) + (1e18 * 0.5%)) / 2e18 = 0.375%
-      const nextTimestamp = (await getCurrentBlockTimestamp()) + TIME.WEEKS * 2
-      await setNextTimestamp(nextTimestamp)
-      await metaSwap
-        .connect(user2)
-        .addLiquidity([String(1e6), String(1e18)], 0, nextTimestamp + 60)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        37500000,
-      )
-
-      // Fee is updated to 0%
-      await metaSwap.setDefaultWithdrawFee(String(0))
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        0,
-      )
-
-      // 2 weeks pass
-      await setTimestamp((await getCurrentBlockTimestamp()) + TIME.WEEKS * 2)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        0,
-      )
-    })
-
-    it("Decrease withdraw fee from 1% to 0.5%", async () => {
-      await metaSwap.setDefaultWithdrawFee(String(1e8))
-
-      // User 2 adds liquidity once when fee is 1%
-      await metaSwap
-        .connect(user2)
-        .addLiquidity(
-          [String(1e6), String(1e18)],
-          0,
-          (await getCurrentBlockTimestamp()) + 60,
-        )
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        100000000,
-      )
-
-      // User 2 adds liquidity again at 2 weeks time
-      // First deposit is discounted to half. Full fee is applied to second deposit
-      // Total withdraw fee should come out to 0.75%
-      // ((1e18 * 0.5%) + (1e18 * 1%)) / 2e18 = 0.75%
-      const nextTimestamp = (await getCurrentBlockTimestamp()) + TIME.WEEKS * 2
-      await setNextTimestamp(nextTimestamp)
-      await metaSwap
-        .connect(user2)
-        .addLiquidity([String(1e6), String(1e18)], 0, nextTimestamp + 60)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        75000000,
-      )
-
-      // Fee is decreased to 0.5%
-      // Fee should decrease by half
-      await metaSwap.setDefaultWithdrawFee(String(5e7))
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        37499984,
-      )
-
-      // 2 weeks pass
-      await setTimestamp((await getCurrentBlockTimestamp()) + TIME.WEEKS * 2)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        18749984,
-      )
-
-      // 2 weeks pass. This is 4 weeks mark since last deposit. Fee should be 0.
-      await setTimestamp((await getCurrentBlockTimestamp()) + TIME.WEEKS * 2)
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.be.eq(
-        0,
-      )
-    })
-  })
-
-  describe("updateUserWithdrawFee", async () => {
-    it("Reverts with 'Only callable by pool token'", async () => {
-      await expect(
-        metaSwap
-          .connect(user1)
-          .updateUserWithdrawFee(ZERO_ADDRESS, String(5e7)),
-      ).to.be.revertedWith("Only callable by pool token")
-    })
-
-    it("Test adding liquidity, and once again at 2 weeks mark then removing all deposits at 4 weeks mark", async () => {
-      await metaSwap.setDefaultWithdrawFee(String(5e7))
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(1e6), String(1e18)], 0, MAX_UINT256)
-      const depositTimestamp = (
-        await metaSwap.getDepositTimestamp(user1Address)
-      ).toNumber()
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(5e7),
-      )
-
-      // 2 weeks after
-      await setNextTimestamp(depositTimestamp + 2 * TIME.WEEKS)
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(2e6), String(2e18)], 0, MAX_UINT256)
-
-      // At 2 weeks mark, half of first deposit's withdrawal fee is discounted, 0.25%.
-      // We are adding twice the amount of first deposit at full withdrawal fee amount, 0.5%.
-      // Remainder of the fees + new fees is then again stretched out to be discounted over the decay period (4 weeks)
-      // (2e18 * 0.25% + 4e18 * 0.5%) / 6e18 = 0.41666666%
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from("41666666"),
-      )
-
-      await metaLPToken
-        .connect(user1)
-        .approve(metaSwap.address, await metaLPToken.balanceOf(user1Address))
-
-      const [firstBalanceBefore, secondBalanceBefore] =
-        await getUserTokenBalances(user1, [dummyUSD, baseLPToken])
-      const currentPoolTokenBalance = await metaLPToken.balanceOf(user1Address)
-
-      // 4 weeks after initial deposit
-      await setNextTimestamp(depositTimestamp + 4 * TIME.WEEKS)
-      await metaSwap
-        .connect(user1)
-        .removeLiquidity(currentPoolTokenBalance, [0, 0], MAX_UINT256)
-
-      const [firstBalanceAfter, secondBalanceAfter] =
-        await getUserTokenBalances(user1, [dummyUSD, baseLPToken])
-
-      // Returned amounts are (100 - 0.41666666 / 2) = 99.79166667% of total deposits
-      // 3e18 * 99.79166667% = 2.9937500001e18
-      expect(firstBalanceAfter.sub(firstBalanceBefore)).to.eq("2993750")
-      expect(secondBalanceAfter.sub(secondBalanceBefore)).to.eq(
-        "2993750000100000000",
-      )
-    })
-
-    it("Verify withdraw fees are updated on transfer", async () => {
-      await metaSwap.setDefaultWithdrawFee(String(5e7))
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(1e6), String(1e18)], 0, MAX_UINT256)
-      const depositTimestamp = (
-        await metaSwap.getDepositTimestamp(user1Address)
-      ).toNumber()
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(5e7),
-      )
-
-      // 2 weeks after
-      await setNextTimestamp(depositTimestamp + 2 * TIME.WEEKS)
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(2e6), String(2e18)], 0, MAX_UINT256)
-
-      // At 2 weeks mark, half of first deposit's withdrawal fee is discounted, 0.25%.
-      // We are adding twice the amount of first deposit at full withdrawal fee amount, 0.5%.
-      // Remainder of the fees + new fees is then again stretched out to be discounted over the decay period (4 weeks)
-      // (2e18 * 0.25% + 4e18 * 0.5%) / 6e18 = 0.41666666%
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from("41666666"),
-      )
-
-      // Transfer some of swap token from user1 to user2
-      await metaLPToken.connect(user1).transfer(user2Address, String(1e18))
-
-      // Verify user1's fee has not changed
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from("41666649"),
-      )
-
-      // Verify user2's fee is set to default value
-      expect(await metaSwap.calculateCurrentWithdrawFee(user2Address)).to.eq(
-        BigNumber.from("50000000"),
-      )
-
-      await setTimestamp((await getCurrentBlockTimestamp()) + 2 * TIME.WEEKS)
-
-      // Verify user2's fee decays as expected
-      let currentFee = await metaSwap.calculateCurrentWithdrawFee(user2Address)
-      expect(currentFee).to.lte(BigNumber.from("25000000"))
-      expect(currentFee).to.gte(BigNumber.from("24993778"))
-
-      // Transfer more tokens to user2
-      await metaLPToken.connect(user1).transfer(user2Address, String(1e18))
-
-      // Verify user2's fee has updated with discounted rate
-      currentFee = await metaSwap.calculateCurrentWithdrawFee(user2Address)
-      expect(currentFee).to.lte(BigNumber.from("37499989"))
-      expect(currentFee).to.gte(BigNumber.from("37497044"))
-    })
-  })
-
-  describe("setDefaultWithdrawFee", () => {
-    it("Emits NewWithdrawFee event", async () => {
-      await expect(metaSwap.setDefaultWithdrawFee(String(5e7))).to.emit(
-        metaSwap,
-        "NewWithdrawFee",
-      )
-    })
-
-    it("Setting the withdraw fee affects past deposits as well", async () => {
-      await metaSwap.setDefaultWithdrawFee(String(5e7))
-      await metaSwap
-        .connect(user1)
-        .addLiquidity([String(1e6), String(1e18)], 0, MAX_UINT256)
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(5e7),
-      )
-
-      await metaSwap.setDefaultWithdrawFee(String(0))
-
-      expect(await metaSwap.calculateCurrentWithdrawFee(user1Address)).to.eq(
-        BigNumber.from(0),
-      )
-    })
-
-    it("Reverts when fee is too high", async () => {
-      await expect(metaSwap.setDefaultWithdrawFee(String(15e8))).to.be.reverted
     })
   })
 

--- a/test/metaSwapDeposit.ts
+++ b/test/metaSwapDeposit.ts
@@ -155,7 +155,6 @@ describe("Meta-Swap Deposit Contract", async () => {
         INITIAL_A_VALUE,
         SWAP_FEE,
         0,
-        0,
         (
           await get("LPToken")
         ).address,
@@ -386,7 +385,6 @@ describe("Meta-Swap Deposit Contract", async () => {
         String(1e6),
       ]
       const minToMint = await metaSwapDeposit.calculateTokenAmount(
-        ownerAddress,
         tokenDepositAmounts,
         true,
       )
@@ -411,7 +409,6 @@ describe("Meta-Swap Deposit Contract", async () => {
         String(1e6),
       ]
       const minToMint = await metaSwapDeposit.calculateTokenAmount(
-        ownerAddress,
         tokenDepositAmounts,
         true,
       )
@@ -446,7 +443,6 @@ describe("Meta-Swap Deposit Contract", async () => {
         String(0),
       ]
       const minToMint = await metaSwapDeposit.calculateTokenAmount(
-        ownerAddress,
         tokenDepositAmounts,
         true,
       )
@@ -470,7 +466,6 @@ describe("Meta-Swap Deposit Contract", async () => {
     it("Succeeds when depositing single token (base swap level)", async () => {
       const tokenDepositAmounts = [String(0), String(1e6), String(0), String(0)]
       const minToMint = await metaSwapDeposit.calculateTokenAmount(
-        ownerAddress,
         tokenDepositAmounts,
         true,
       )
@@ -542,7 +537,6 @@ describe("Meta-Swap Deposit Contract", async () => {
 
     it("Succeeds with expected minAmounts", async () => {
       const minAmounts = await metaSwapDeposit.calculateRemoveLiquidity(
-        ownerAddress,
         String(1e18),
       )
       expect(minAmounts[0]).to.eq("504905415701427558")
@@ -625,7 +619,6 @@ describe("Meta-Swap Deposit Contract", async () => {
 
     it("Succeeds when withdrawing via a meta level token", async () => {
       const minAmount = await metaSwapDeposit.calculateRemoveLiquidityOneToken(
-        ownerAddress,
         String(1e18),
         0,
       )
@@ -653,7 +646,6 @@ describe("Meta-Swap Deposit Contract", async () => {
 
     it("Succeeds when withdrawing via a base level token", async () => {
       const minAmount = await metaSwapDeposit.calculateRemoveLiquidityOneToken(
-        ownerAddress,
         String(1e18),
         2,
       )
@@ -727,7 +719,6 @@ describe("Meta-Swap Deposit Contract", async () => {
       // setting that is at least 0.1% when withdrawing meta-level tokens and 0.2% when withdrawing base-level tokens.
       const amounts = [String(1e18), String(0), String(0), String(0)]
       const maxBurnAmount = await metaSwapDeposit.calculateTokenAmount(
-        ownerAddress,
         amounts,
         false,
       )
@@ -745,7 +736,7 @@ describe("Meta-Swap Deposit Contract", async () => {
 
       // Apply 0.1% slippage
       const maxBurnAmount = (
-        await metaSwapDeposit.calculateTokenAmount(ownerAddress, amounts, false)
+        await metaSwapDeposit.calculateTokenAmount(amounts, false)
       )
         .mul(1001)
         .div(1000)
@@ -789,7 +780,7 @@ describe("Meta-Swap Deposit Contract", async () => {
 
       // Apply 0.2% slippage
       const maxBurnAmount = (
-        await metaSwapDeposit.calculateTokenAmount(ownerAddress, amounts, false)
+        await metaSwapDeposit.calculateTokenAmount(amounts, false)
       )
         .mul(1002)
         .div(1000)
@@ -833,7 +824,7 @@ describe("Meta-Swap Deposit Contract", async () => {
 
       // Apply 0.2% slippage
       const maxBurnAmount = (
-        await metaSwapDeposit.calculateTokenAmount(ownerAddress, amounts, false)
+        await metaSwapDeposit.calculateTokenAmount(amounts, false)
       )
         .mul(1002)
         .div(1000)

--- a/test/swap4tokens.ts
+++ b/test/swap4tokens.ts
@@ -263,6 +263,117 @@ describe("Swap with 4 tokens", () => {
     })
   })
 
+  describe("withdrawAdminFees", () => {
+    it("Reverts when called by non-owners", async () => {
+      await expect(swap.connect(user1).withdrawAdminFees()).to.be.reverted
+      await expect(swap.connect(user2).withdrawAdminFees()).to.be.reverted
+    })
+
+    it("Succeeds when there are no fees withdrawn", async () => {
+      // Sets adminFee to 1% of the swap fees
+      await swap.setAdminFee(BigNumber.from(10 ** 8))
+
+      const balancesBefore = await getUserTokenBalances(owner, [
+        DAI,
+        USDC,
+        USDT,
+        SUSD,
+      ])
+
+      await swap.withdrawAdminFees()
+
+      const balancesAfter = await getUserTokenBalances(owner, [
+        DAI,
+        USDC,
+        USDT,
+        SUSD,
+      ])
+
+      expect(balancesBefore).to.eql(balancesAfter)
+    })
+
+    it("Succeeds with expected amount of fees withdrawn", async () => {
+      // Sets adminFee to 1% of the swap fees
+      await swap.setAdminFee(BigNumber.from(10 ** 8))
+      await swap.connect(user1).swap(0, 1, String(1e18), 0, MAX_UINT256)
+      await swap.connect(user1).swap(1, 0, String(1e6), 0, MAX_UINT256)
+
+      expect(await swap.getAdminBalance(0)).to.eq(String(10003917589952))
+      expect(await swap.getAdminBalance(1)).to.eq(String(9))
+
+      const balancesBefore = await getUserTokenBalances(owner, [
+        DAI,
+        USDC,
+        USDT,
+        SUSD,
+      ])
+
+      await swap.withdrawAdminFees()
+
+      const balancesAfter = await getUserTokenBalances(owner, [
+        DAI,
+        USDC,
+        USDT,
+        SUSD,
+      ])
+
+      expect(balancesAfter[0].sub(balancesBefore[0])).to.eq(
+        String(10003917589952),
+      )
+      expect(balancesAfter[1].sub(balancesBefore[1])).to.eq(String(9))
+    })
+
+    it("Withdrawing admin fees has no impact on users' withdrawal", async () => {
+      // Sets adminFee to 1% of the swap fees
+      await swap.setAdminFee(BigNumber.from(10 ** 8))
+      await swap
+        .connect(user1)
+        .addLiquidity(
+          [String(1e18), String(1e6), String(1e6), String(1e18)],
+          0,
+          MAX_UINT256,
+        )
+
+      for (let i = 0; i < 10; i++) {
+        await swap.connect(user2).swap(0, 1, String(1e18), 0, MAX_UINT256)
+        await swap.connect(user2).swap(1, 0, String(1e6), 0, MAX_UINT256)
+      }
+
+      expect(await swap.getAdminBalance(0)).to.eq(String(100038269603084))
+      expect(await swap.getAdminBalance(1)).to.eq(String(90))
+
+      await swap.withdrawAdminFees()
+
+      const balancesBefore = await getUserTokenBalances(user1, [
+        DAI,
+        USDC,
+        USDT,
+        SUSD,
+      ])
+
+      const user1LPTokenBalance = await swapToken.balanceOf(user1Address)
+      await swapToken.connect(user1).approve(swap.address, user1LPTokenBalance)
+      await swap
+        .connect(user1)
+        .removeLiquidity(user1LPTokenBalance, [0, 0, 0, 0], MAX_UINT256)
+
+      const balancesAfter = await getUserTokenBalances(user1, [
+        DAI,
+        USDC,
+        USDT,
+        SUSD,
+      ])
+
+      expect(balancesAfter[0].sub(balancesBefore[0])).to.eq(
+        BigNumber.from("1000119153497686425"),
+      )
+
+      expect(balancesAfter[1].sub(balancesBefore[1])).to.eq(
+        BigNumber.from("1000269"),
+      )
+    })
+  })
+
   describe("Check for timestamp manipulations", () => {
     it("Check for maximum differences in A and virtual price when increasing", async () => {
       // Create imbalanced pool to measure virtual price change

--- a/test/swap4tokens.ts
+++ b/test/swap4tokens.ts
@@ -107,7 +107,6 @@ describe("Swap with 4 tokens", () => {
         INITIAL_A_VALUE,
         SWAP_FEE,
         0,
-        0,
         (
           await get("LPToken")
         ).address,
@@ -153,7 +152,6 @@ describe("Swap with 4 tokens", () => {
   describe("addLiquidity", () => {
     it("Add liquidity succeeds with pool with 4 tokens", async () => {
       const calcTokenAmount = await swap.calculateTokenAmount(
-        user1Address,
         [String(1e18), 0, 0, 0],
         true,
       )
@@ -205,7 +203,6 @@ describe("Swap with 4 tokens", () => {
   describe("removeLiquidity", () => {
     it("Remove Liquidity succeeds", async () => {
       const calcTokenAmount = await swap.calculateTokenAmount(
-        user1Address,
         [String(1e18), 0, 0, 0],
         true,
       )
@@ -227,7 +224,6 @@ describe("Swap with 4 tokens", () => {
 
       // Calculate expected amounts of tokens user1 will receive
       const expectedAmounts = await swap.calculateRemoveLiquidity(
-        user1Address,
         "999355335447632820",
       )
 

--- a/test/swapDeployer.ts
+++ b/test/swapDeployer.ts
@@ -117,7 +117,6 @@ describe("Swap Deployer", () => {
         INITIAL_A_VALUE,
         SWAP_FEE,
         0,
-        0,
         (
           await deployments.get("LPToken")
         ).address,
@@ -131,7 +130,6 @@ describe("Swap Deployer", () => {
         LP_TOKEN_SYMBOL,
         INITIAL_A_VALUE,
         SWAP_FEE,
-        0,
         0,
         (
           await deployments.get("LPToken")
@@ -180,7 +178,6 @@ describe("Swap Deployer", () => {
   describe("addLiquidity", () => {
     it("Add liquidity succeeds with pool with 4 tokens", async () => {
       const calcTokenAmount = await swapClone.calculateTokenAmount(
-        user1Address,
         [String(1e18), 0, 0, 0],
         true,
       )
@@ -233,7 +230,6 @@ describe("Swap Deployer", () => {
   describe("removeLiquidity", () => {
     it("Remove Liquidity succeeds", async () => {
       const calcTokenAmount = await swapClone.calculateTokenAmount(
-        user1Address,
         [String(1e18), 0, 0, 0],
         true,
       )
@@ -255,7 +251,6 @@ describe("Swap Deployer", () => {
 
       // Calculate expected amounts of tokens user1 will receive
       const expectedAmounts = await swapClone.calculateRemoveLiquidity(
-        user1Address,
         "999355335447632820",
       )
 

--- a/test/swapInitialize.ts
+++ b/test/swapInitialize.ts
@@ -71,7 +71,6 @@ describe("Swap", () => {
           INITIAL_A_VALUE,
           SWAP_FEE,
           0,
-          0,
           (
             await deployments.get("LPToken")
           ).address,
@@ -88,7 +87,6 @@ describe("Swap", () => {
           LP_TOKEN_SYMBOL,
           INITIAL_A_VALUE,
           SWAP_FEE,
-          0,
           0,
           (
             await deployments.get("LPToken")
@@ -107,7 +105,6 @@ describe("Swap", () => {
           INITIAL_A_VALUE,
           SWAP_FEE,
           0,
-          0,
           (
             await deployments.get("LPToken")
           ).address,
@@ -124,7 +121,6 @@ describe("Swap", () => {
           LP_TOKEN_SYMBOL,
           INITIAL_A_VALUE,
           SWAP_FEE,
-          0,
           0,
           (
             await deployments.get("LPToken")
@@ -143,7 +139,6 @@ describe("Swap", () => {
           INITIAL_A_VALUE,
           SWAP_FEE,
           0,
-          0,
           (
             await deployments.get("LPToken")
           ).address,
@@ -160,7 +155,6 @@ describe("Swap", () => {
           LP_TOKEN_SYMBOL,
           INITIAL_A_VALUE,
           SWAP_FEE,
-          0,
           0,
           (
             await deployments.get("LPToken")
@@ -179,7 +173,6 @@ describe("Swap", () => {
           10e6 + 1,
           SWAP_FEE,
           0,
-          0,
           (
             await deployments.get("LPToken")
           ).address,
@@ -196,7 +189,6 @@ describe("Swap", () => {
           LP_TOKEN_SYMBOL,
           INITIAL_A_VALUE,
           10e8 + 1,
-          0,
           0,
           (
             await deployments.get("LPToken")
@@ -215,30 +207,11 @@ describe("Swap", () => {
           INITIAL_A_VALUE,
           SWAP_FEE,
           10e10 + 1,
-          0,
           (
             await deployments.get("LPToken")
           ).address,
         ),
       ).to.be.revertedWith("_adminFee exceeds maximum")
-    })
-
-    it("Reverts with '_withdrawFee exceeds maximum'", async () => {
-      await expect(
-        swap.initialize(
-          [firstToken.address, secondToken.address],
-          [18, 18],
-          LP_TOKEN_NAME,
-          LP_TOKEN_SYMBOL,
-          INITIAL_A_VALUE,
-          SWAP_FEE,
-          0,
-          10e8 + 1,
-          (
-            await deployments.get("LPToken")
-          ).address,
-        ),
-      ).to.be.revertedWith("_withdrawFee exceeds maximum")
     })
 
     it("Reverts when the LPToken target does not implement initialize function", async () => {
@@ -250,7 +223,6 @@ describe("Swap", () => {
           LP_TOKEN_SYMBOL,
           INITIAL_A_VALUE,
           SWAP_FEE,
-          0,
           0,
           ZERO_ADDRESS,
         ),

--- a/test/virtualBridge.ts
+++ b/test/virtualBridge.ts
@@ -217,7 +217,6 @@ describe("Virtual swap bridge [ @skip-on-coverage ]", () => {
         INITIAL_A_VALUE,
         SWAP_FEE,
         0,
-        0,
         (
           await deployments.get("LPToken")
         ).address,
@@ -237,7 +236,6 @@ describe("Virtual swap bridge [ @skip-on-coverage ]", () => {
         LP_TOKEN_SYMBOL,
         INITIAL_A_VALUE,
         SWAP_FEE,
-        0,
         0,
         (
           await deployments.get("LPToken")


### PR DESCRIPTION
This changes the structure of `swapStorage` struct and removes calculation code for withdraw fees. Frontend should use old ABI for the currently deployed pools on the mainnet - otherwise use the new ABI from this PR. @hammeiam 