### PR TITLE
Reduce redundancy in test files

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -94,11 +94,23 @@ if (process.env.ACCOUNT_PRIVATE_KEYS) {
 }
 
 if (process.env.FORK_MAINNET && config.networks) {
-  config.networks.hardhat = {
-    forking: {
-      url: process.env.ALCHEMY_API ? process.env.ALCHEMY_API : "",
+  console.log("FORK_MAINNET is set to true")
+  config = {
+    ...config,
+    networks: {
+      ...config.networks,
+      hardhat: {
+        forking: {
+          url: process.env.ALCHEMY_API ? process.env.ALCHEMY_API : "",
+        },
+        chainId: 1,
+      },
     },
-    chainId: 1,
+    external: {
+      deployments: {
+        hardhat: ["deployments/mainnet"],
+      },
+    },
   }
 }
 

--- a/test/flashloan.ts
+++ b/test/flashloan.ts
@@ -1,5 +1,10 @@
 import { BigNumber, Signer } from "ethers"
-import { MAX_UINT256, getUserTokenBalance, asyncForEach } from "./testUtils"
+import {
+  MAX_UINT256,
+  getUserTokenBalance,
+  asyncForEach,
+  getDeployedContractByName,
+} from "./testUtils"
 import { solidity } from "ethereum-waffle"
 
 import { GenericERC20 } from "../build/typechain/GenericERC20"
@@ -49,6 +54,8 @@ describe("Swap Flashloan", () => {
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
       const { get } = deployments
+      const getByName = (name: string) =>
+        getDeployedContractByName(deployments, name)
       await deployments.fixture() // ensure you start from a fresh deployments
 
       TOKENS.length = 0
@@ -64,9 +71,9 @@ describe("Swap Flashloan", () => {
       const erc20Factory = await ethers.getContractFactory("GenericERC20")
 
       // Deploy dummy tokens
-      DAI = (await erc20Factory.deploy("DAI", "DAI", "18")) as GenericERC20
-      USDC = (await erc20Factory.deploy("USDC", "USDC", "6")) as GenericERC20
-      USDT = (await erc20Factory.deploy("USDT", "USDT", "6")) as GenericERC20
+      DAI = (await getByName("DAI")) as GenericERC20
+      USDC = (await getByName("USDC")) as GenericERC20
+      USDT = (await getByName("USDT")) as GenericERC20
       SUSD = (await erc20Factory.deploy("SUSD", "SUSD", "18")) as GenericERC20
 
       TOKENS.push(DAI, USDC, USDT, SUSD)
@@ -82,18 +89,8 @@ describe("Swap Flashloan", () => {
         },
       )
 
-      const swapFlashLoanFactory = await ethers.getContractFactory(
-        "SwapFlashLoan",
-        {
-          libraries: {
-            SwapUtils: (await get("SwapUtils")).address,
-            AmplificationUtils: (await get("AmplificationUtils")).address,
-          },
-        },
-      )
-
       // Deploy Swap with SwapUtils library
-      swapFlashLoan = (await swapFlashLoanFactory.deploy()) as SwapFlashLoan
+      swapFlashLoan = (await getByName("SwapFlashLoan")) as SwapFlashLoan
 
       await swapFlashLoan.initialize(
         [DAI.address, USDC.address, USDT.address, SUSD.address],

--- a/test/metaSwap.ts
+++ b/test/metaSwap.ts
@@ -11,6 +11,7 @@ import {
   setNextTimestamp,
   setTimestamp,
   forceAdvanceOneBlock,
+  getDeployedContractByName,
 } from "./testUtils"
 import { deployContract, solidity } from "ethereum-waffle"
 import { deployments } from "hardhat"
@@ -20,7 +21,6 @@ import GenericERC20Artifact from "../build/artifacts/contracts/helper/GenericERC
 import { LPToken } from "../build/typechain/LPToken"
 import LPTokenArtifact from "../build/artifacts/contracts/LPToken.sol/LPToken.json"
 import { Swap } from "../build/typechain/Swap"
-import SwapArtifact from "../build/artifacts/contracts/Swap.sol/Swap.json"
 import { MetaSwap } from "../build/typechain/MetaSwap"
 import MetaSwapArtifact from "../build/artifacts/contracts/meta/MetaSwap.sol/MetaSwap.json"
 import { MetaSwapUtils } from "../build/typechain/MetaSwapUtils"
@@ -57,6 +57,8 @@ describe("Meta-Swap", async () => {
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
       const { get } = deployments
+      const getByName = (name: string) =>
+        getDeployedContractByName(deployments, name)
       await deployments.fixture() // ensure you start from a fresh deployments
 
       signers = await ethers.getSigners()
@@ -67,36 +69,12 @@ describe("Meta-Swap", async () => {
       user1Address = await user1.getAddress()
       user2Address = await user2.getAddress()
 
-      // Deploy a swap pool
-      baseSwap = (await deployContractWithLibraries(
-        owner as Wallet,
-        SwapArtifact,
-        {
-          SwapUtils: (await get("SwapUtils")).address,
-          AmplificationUtils: (await get("AmplificationUtils")).address,
-        },
-      )) as Swap
+      // Get deployed Swap
+      baseSwap = (await getByName("Swap")) as Swap
 
-      dai = (await ethers.getContractAt(
-        GenericERC20Artifact.abi,
-        (
-          await get("DAI")
-        ).address,
-      )) as GenericERC20
-
-      usdc = (await ethers.getContractAt(
-        GenericERC20Artifact.abi,
-        (
-          await get("USDC")
-        ).address,
-      )) as GenericERC20
-
-      usdt = (await ethers.getContractAt(
-        GenericERC20Artifact.abi,
-        (
-          await get("USDT")
-        ).address,
-      )) as GenericERC20
+      dai = (await getByName("DAI")) as GenericERC20
+      usdc = (await getByName("USDC")) as GenericERC20
+      usdt = (await getByName("USDT")) as GenericERC20
 
       await baseSwap.initialize(
         [dai.address, usdc.address, usdt.address],

--- a/test/metaSwapDecimals.ts
+++ b/test/metaSwapDecimals.ts
@@ -11,6 +11,7 @@ import {
   setNextTimestamp,
   setTimestamp,
   forceAdvanceOneBlock,
+  getDeployedContractByName,
 } from "./testUtils"
 import { deployContract, solidity } from "ethereum-waffle"
 import { deployments } from "hardhat"
@@ -20,7 +21,6 @@ import GenericERC20Artifact from "../build/artifacts/contracts/helper/GenericERC
 import { LPToken } from "../build/typechain/LPToken"
 import LPTokenArtifact from "../build/artifacts/contracts/LPToken.sol/LPToken.json"
 import { Swap } from "../build/typechain/Swap"
-import SwapArtifact from "../build/artifacts/contracts/Swap.sol/Swap.json"
 import { MetaSwap } from "../build/typechain/MetaSwap"
 import MetaSwapArtifact from "../build/artifacts/contracts/meta/MetaSwap.sol/MetaSwap.json"
 import { MetaSwapUtils } from "../build/typechain/MetaSwapUtils"
@@ -57,6 +57,8 @@ describe("Meta-Swap", async () => {
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
       const { get } = deployments
+      const getByName = (name: string) =>
+        getDeployedContractByName(deployments, name)
       await deployments.fixture() // ensure you start from a fresh deployments
 
       signers = await ethers.getSigners()
@@ -67,36 +69,12 @@ describe("Meta-Swap", async () => {
       user1Address = await user1.getAddress()
       user2Address = await user2.getAddress()
 
-      // Deploy a swap pool
-      baseSwap = (await deployContractWithLibraries(
-        owner as Wallet,
-        SwapArtifact,
-        {
-          SwapUtils: (await get("SwapUtils")).address,
-          AmplificationUtils: (await get("AmplificationUtils")).address,
-        },
-      )) as Swap
+      // Get deployed Swap
+      baseSwap = (await getByName("Swap")) as Swap
 
-      dai = (await ethers.getContractAt(
-        GenericERC20Artifact.abi,
-        (
-          await get("DAI")
-        ).address,
-      )) as GenericERC20
-
-      usdc = (await ethers.getContractAt(
-        GenericERC20Artifact.abi,
-        (
-          await get("USDC")
-        ).address,
-      )) as GenericERC20
-
-      usdt = (await ethers.getContractAt(
-        GenericERC20Artifact.abi,
-        (
-          await get("USDT")
-        ).address,
-      )) as GenericERC20
+      dai = (await getByName("DAI")) as GenericERC20
+      usdc = (await getByName("USDC")) as GenericERC20
+      usdt = (await getByName("USDT")) as GenericERC20
 
       await baseSwap.initialize(
         [dai.address, usdc.address, usdt.address],

--- a/test/metaSwapDeposit.ts
+++ b/test/metaSwapDeposit.ts
@@ -6,6 +6,7 @@ import {
   getCurrentBlockTimestamp,
   getUserTokenBalance,
   getUserTokenBalances,
+  getDeployedContractByName,
 } from "./testUtils"
 import { deployContract, solidity } from "ethereum-waffle"
 import { deployments } from "hardhat"
@@ -15,7 +16,6 @@ import GenericERC20Artifact from "../build/artifacts/contracts/helper/GenericERC
 import { LPToken } from "../build/typechain/LPToken"
 import LPTokenArtifact from "../build/artifacts/contracts/LPToken.sol/LPToken.json"
 import { Swap } from "../build/typechain/Swap"
-import SwapArtifact from "../build/artifacts/contracts/Swap.sol/Swap.json"
 import { MetaSwap } from "../build/typechain/MetaSwap"
 import MetaSwapArtifact from "../build/artifacts/contracts/meta/MetaSwap.sol/MetaSwap.json"
 import { MetaSwapDeposit } from "../build/typechain/MetaSwapDeposit"
@@ -53,6 +53,8 @@ describe("Meta-Swap Deposit Contract", async () => {
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
       const { get } = deployments
+      const getByName = (name: string) =>
+        getDeployedContractByName(deployments, name)
       await deployments.fixture() // ensure you start from a fresh deployments
 
       signers = await ethers.getSigners()
@@ -64,35 +66,11 @@ describe("Meta-Swap Deposit Contract", async () => {
       user2Address = await user2.getAddress()
 
       // Deploy a swap pool
-      baseSwap = (await deployContractWithLibraries(
-        owner as Wallet,
-        SwapArtifact,
-        {
-          SwapUtils: (await get("SwapUtils")).address,
-          AmplificationUtils: (await get("AmplificationUtils")).address,
-        },
-      )) as Swap
+      baseSwap = (await getByName("Swap")) as Swap
 
-      dai = (await ethers.getContractAt(
-        GenericERC20Artifact.abi,
-        (
-          await get("DAI")
-        ).address,
-      )) as GenericERC20
-
-      usdc = (await ethers.getContractAt(
-        GenericERC20Artifact.abi,
-        (
-          await get("USDC")
-        ).address,
-      )) as GenericERC20
-
-      usdt = (await ethers.getContractAt(
-        GenericERC20Artifact.abi,
-        (
-          await get("USDT")
-        ).address,
-      )) as GenericERC20
+      dai = (await getByName("DAI")) as GenericERC20
+      usdc = (await getByName("USDC")) as GenericERC20
+      usdt = (await getByName("USDT")) as GenericERC20
 
       await baseSwap.initialize(
         [dai.address, usdc.address, usdt.address],

--- a/test/swap.ts
+++ b/test/swap.ts
@@ -10,6 +10,7 @@ import {
   setNextTimestamp,
   setTimestamp,
   forceAdvanceOneBlock,
+  getDeployedContractByName,
 } from "./testUtils"
 import { solidity } from "ethereum-waffle"
 import { deployments } from "hardhat"
@@ -57,6 +58,8 @@ describe("Swap", async () => {
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
       const { get } = deployments
+      const getByName = (name: string) =>
+        getDeployedContractByName(deployments, name)
       await deployments.fixture() // ensure you start from a fresh deployments
 
       signers = await ethers.getSigners()
@@ -89,14 +92,8 @@ describe("Swap", async () => {
         await secondToken.mint(address, String(1e20))
       })
 
-      // Deploy Swap with SwapUtils library
-      const swapFactory = await ethers.getContractFactory("Swap", {
-        libraries: {
-          SwapUtils: (await get("SwapUtils")).address,
-          AmplificationUtils: (await get("AmplificationUtils")).address,
-        },
-      })
-      swap = (await swapFactory.deploy()) as Swap
+      // Get Swap contract
+      swap = (await getByName("Swap")) as Swap
 
       await swap.initialize(
         [firstToken.address, secondToken.address],

--- a/test/swapInitialize.ts
+++ b/test/swapInitialize.ts
@@ -1,5 +1,5 @@
 import { Signer } from "ethers"
-import { ZERO_ADDRESS } from "./testUtils"
+import { getDeployedContractByName, ZERO_ADDRESS } from "./testUtils"
 import { solidity } from "ethereum-waffle"
 import { deployments } from "hardhat"
 
@@ -26,6 +26,8 @@ describe("Swap", () => {
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
       const { get } = deployments
+      const getByName = (name: string) =>
+        getDeployedContractByName(deployments, name)
       await deployments.fixture() // ensure you start from a fresh deployments
 
       signers = await ethers.getSigners()
@@ -46,13 +48,7 @@ describe("Swap", () => {
         "18",
       )) as GenericERC20
 
-      const swapFactory = await ethers.getContractFactory("Swap", {
-        libraries: {
-          SwapUtils: (await get("SwapUtils")).address,
-          AmplificationUtils: (await get("AmplificationUtils")).address,
-        },
-      })
-      swap = (await swapFactory.deploy()) as Swap
+      swap = (await getByName("Swap")) as Swap
     },
   )
 

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -7,6 +7,7 @@ import { Contract } from "@ethersproject/contracts"
 import { ERC20 } from "../build/typechain/ERC20"
 import { Swap } from "../build/typechain/Swap"
 import merkleTreeDataTest from "../test/exampleMerkleTree.json"
+import { DeploymentsExtension } from "hardhat-deploy/dist/types"
 
 export const MAX_UINT256 = ethers.constants.MaxUint256
 export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
@@ -174,4 +175,12 @@ export async function asyncForEach<T>(
   for (let index = 0; index < array.length; index++) {
     await callback(array[index], index)
   }
+}
+
+export async function getDeployedContractByName(
+  deployments: DeploymentsExtension,
+  name: string,
+): Promise<Contract> {
+  const deployment = await deployments.get(name)
+  return ethers.getContractAt(deployment.abi, deployment.address)
 }


### PR DESCRIPTION
Instead of re-deploying contracts, use already deployed contracts for testing.
This allows certain tests to be run on forked mainnet with minimal changes.