### PR TITLE
Added initializer to PermissionlessMetaSwap, typos

### DIFF
--- a/contracts/permissionless/PermissionlessMetaSwap.sol
+++ b/contracts/permissionless/PermissionlessMetaSwap.sol
@@ -44,6 +44,31 @@ contract PermissionlessMetaSwap is MetaSwap, ShareProtocolFee {
 
     /*** ADMIN FUNCTIONS ***/
 
+    function initializeMetaSwap(
+        IERC20[] memory _pooledTokens,
+        uint8[] memory decimals,
+        string memory lpTokenName,
+        string memory lpTokenSymbol,
+        uint256 _a,
+        uint256 _fee,
+        uint256 _adminFee,
+        address lpTokenTargetAddress,
+        ISwap baseSwap
+    ) public payable virtual override initializer {
+        MetaSwap.initializeMetaSwap(
+            _pooledTokens,
+            decimals,
+            lpTokenName,
+            lpTokenSymbol,
+            _a,
+            _fee,
+            _adminFee,
+            lpTokenTargetAddress,
+            baseSwap
+        );
+        _updateFeeCollectorCache(MASTER_REGISTRY);
+    }
+
     /**
      * @notice Withdraw all admin fees to the contract owner and the fee collector
      */
@@ -55,7 +80,7 @@ contract PermissionlessMetaSwap is MetaSwap, ShareProtocolFee {
     {
         require(
             msg.sender == owner() || msg.sender == feeCollector,
-            "Caller is not authroized"
+            "Caller is not authorized"
         );
         PermissionlessSwapUtils.withdrawAdminFees(
             swapStorage,

--- a/contracts/permissionless/PermissionlessSwap.sol
+++ b/contracts/permissionless/PermissionlessSwap.sol
@@ -51,7 +51,7 @@ contract PermissionlessSwap is Swap, ShareProtocolFee {
         uint256 _fee,
         uint256 _adminFee,
         address lpTokenTargetAddress
-    ) public payable virtual override {
+    ) public payable virtual override initializer {
         Swap.initialize(
             _pooledTokens,
             decimals,
@@ -76,7 +76,7 @@ contract PermissionlessSwap is Swap, ShareProtocolFee {
     {
         require(
             msg.sender == owner() || msg.sender == feeCollector,
-            "Caller is not authroized"
+            "Caller is not authorized"
         );
         PermissionlessSwapUtils.withdrawAdminFees(
             swapStorage,


### PR DESCRIPTION
Added initializeMetaSwap() to PermissionlessMetaSwap.sol, fixed typos.