### PR TITLE
Prevent re-saving LP tokens for future deploy runs

### DIFF
--- a/deploy/mainnet/101_deploy_BTCPool.ts
+++ b/deploy/mainnet/101_deploy_BTCPool.ts
@@ -3,7 +3,7 @@ import { DeployFunction } from "hardhat-deploy/types"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts } = hre
-  const { deploy, get, log, read, save } = deployments
+  const { deploy, get, log, read, save, getOrNull } = deployments
   const { deployer } = await getNamedAccounts()
 
   // Constructor arguments
@@ -22,34 +22,39 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const WITHDRAW_FEE = 0
   const ALLOWLIST_ADDRESS = (await get("Allowlist")).address
 
-  await deploy("SaddleBTCPool", {
-    from: deployer,
-    log: true,
-    contract: "SwapGuarded",
-    libraries: {
-      SwapUtilsGuarded: (await get("SwapUtilsGuarded")).address,
-    },
-    args: [
-      TOKEN_ADDRESSES,
-      TOKEN_DECIMALS,
-      LP_TOKEN_NAME,
-      LP_TOKEN_SYMBOL,
-      INITIAL_A,
-      SWAP_FEE, // 4bps
-      ADMIN_FEE,
-      WITHDRAW_FEE,
-      ALLOWLIST_ADDRESS,
-    ],
-    skipIfAlreadyDeployed: true,
-  })
+  const poolDeployment = await getOrNull("SaddleBTCPool")
+  if (poolDeployment) {
+    log(`reusing SaddleBTCPool at ${poolDeployment.address}`)
+  } else {
+    await deploy("SaddleBTCPool", {
+      from: deployer,
+      log: true,
+      contract: "SwapGuarded",
+      libraries: {
+        SwapUtilsGuarded: (await get("SwapUtilsGuarded")).address,
+      },
+      args: [
+        TOKEN_ADDRESSES,
+        TOKEN_DECIMALS,
+        LP_TOKEN_NAME,
+        LP_TOKEN_SYMBOL,
+        INITIAL_A,
+        SWAP_FEE, // 4bps
+        ADMIN_FEE,
+        WITHDRAW_FEE,
+        ALLOWLIST_ADDRESS,
+      ],
+      skipIfAlreadyDeployed: true,
+    })
 
-  const lpTokenAddress = (await read("SaddleBTCPool", "swapStorage")).lpToken
-  log(`BTC pool LP Token at ${lpTokenAddress}`)
+    const lpTokenAddress = (await read("SaddleBTCPool", "swapStorage")).lpToken
+    log(`BTC pool LP Token at ${lpTokenAddress}`)
 
-  await save("SaddleBTCPoolLPToken", {
-    abi: (await get("TBTC")).abi, // Generic ERC20 ABI
-    address: lpTokenAddress,
-  })
+    await save("SaddleBTCPoolLPToken", {
+      abi: (await get("TBTC")).abi, // Generic ERC20 ABI
+      address: lpTokenAddress,
+    })
+  }
 }
 export default func
 func.tags = ["BTCPool"]

--- a/deploy/mainnet/111_deploy_USDPool.ts
+++ b/deploy/mainnet/111_deploy_USDPool.ts
@@ -56,15 +56,15 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       abi: (await get("SwapFlashLoanV1")).abi,
       address: usdSwapAddress,
     })
+
+    const lpTokenAddress = (await read("SaddleUSDPool", "swapStorage")).lpToken
+    log(`USD pool LP Token at ${lpTokenAddress}`)
+
+    await save("SaddleUSDPoolLPToken", {
+      abi: (await get("TBTC")).abi, // Generic ERC20 ABI
+      address: lpTokenAddress,
+    })
   }
-
-  const lpTokenAddress = (await read("SaddleUSDPool", "swapStorage")).lpToken
-  log(`USD pool LP Token at ${lpTokenAddress}`)
-
-  await save("SaddleUSDPoolLPToken", {
-    abi: (await get("TBTC")).abi, // Generic ERC20 ABI
-    address: lpTokenAddress,
-  })
 }
 export default func
 func.tags = ["USDPool"]

--- a/deploy/mainnet/121_deploy_VETH2Pool.ts
+++ b/deploy/mainnet/121_deploy_VETH2Pool.ts
@@ -55,15 +55,16 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       abi: (await get("SwapFlashLoanV1")).abi,
       address: veth2SwapAddress,
     })
+
+    const lpTokenAddress = (await read("SaddleVETH2Pool", "swapStorage"))
+      .lpToken
+    log(`vETH2 pool LP Token at ${lpTokenAddress}`)
+
+    await save("SaddleVETH2PoolLPToken", {
+      abi: (await get("TBTC")).abi, // Generic ERC20 ABI
+      address: lpTokenAddress,
+    })
   }
-
-  const lpTokenAddress = (await read("SaddleVETH2Pool", "swapStorage")).lpToken
-  log(`vETH2 pool LP Token at ${lpTokenAddress}`)
-
-  await save("SaddleVETH2PoolLPToken", {
-    abi: (await get("TBTC")).abi, // Generic ERC20 ABI
-    address: lpTokenAddress,
-  })
 }
 export default func
 func.tags = ["VETH2Pool"]

--- a/deploy/mainnet/140_deploy_alETHPool.ts
+++ b/deploy/mainnet/140_deploy_alETHPool.ts
@@ -54,15 +54,16 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       abi: (await get("SwapFlashLoan")).abi,
       address: alETHSwapAddress,
     })
+
+    const lpTokenAddress = (await read("SaddleALETHPool", "swapStorage"))
+      .lpToken
+    log(`alETH pool LP Token at ${lpTokenAddress}`)
+
+    await save("SaddleALETHPoolLPToken", {
+      abi: (await get("TBTC")).abi, // Generic ERC20 ABI
+      address: lpTokenAddress,
+    })
   }
-
-  const lpTokenAddress = (await read("SaddleALETHPool", "swapStorage")).lpToken
-  log(`alETH pool LP Token at ${lpTokenAddress}`)
-
-  await save("SaddleALETHPoolLPToken", {
-    abi: (await get("TBTC")).abi, // Generic ERC20 ABI
-    address: lpTokenAddress,
-  })
 }
 export default func
 func.tags = ["ALETHPool"]

--- a/deploy/mainnet/150_deploy_D4Pool.ts
+++ b/deploy/mainnet/150_deploy_D4Pool.ts
@@ -53,15 +53,15 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       abi: (await get("SwapFlashLoan")).abi,
       address: D4SwapAddress,
     })
+
+    const lpTokenAddress = (await read("SaddleD4Pool", "swapStorage")).lpToken
+    log(`D4 pool LP Token at ${lpTokenAddress}`)
+
+    await save("SaddleD4PoolLPToken", {
+      abi: (await get("TBTC")).abi, // Generic ERC20 ABI
+      address: lpTokenAddress,
+    })
   }
-
-  const lpTokenAddress = (await read("SaddleD4Pool", "swapStorage")).lpToken
-  log(`D4 pool LP Token at ${lpTokenAddress}`)
-
-  await save("SaddleD4PoolLPToken", {
-    abi: (await get("TBTC")).abi, // Generic ERC20 ABI
-    address: lpTokenAddress,
-  })
 }
 export default func
 func.tags = ["D4Pool"]

--- a/deploy/mainnet/191_deploy_BTCPoolV2.ts
+++ b/deploy/mainnet/191_deploy_BTCPoolV2.ts
@@ -52,15 +52,16 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       abi: (await get("SwapFlashLoan")).abi,
       address: btcSwapAddress,
     })
+
+    const lpTokenAddress = (await read("SaddleBTCPoolV2", "swapStorage"))
+      .lpToken
+    log(`BTC pool V2 LP Token at ${lpTokenAddress}`)
+
+    await save("SaddleBTCPoolV2LPToken", {
+      abi: (await get("WBTC")).abi, // Generic ERC20 ABI
+      address: lpTokenAddress,
+    })
   }
-
-  const lpTokenAddress = (await read("SaddleBTCPoolV2", "swapStorage")).lpToken
-  log(`BTC pool V2 LP Token at ${lpTokenAddress}`)
-
-  await save("SaddleBTCPoolV2LPToken", {
-    abi: (await get("WBTC")).abi, // Generic ERC20 ABI
-    address: lpTokenAddress,
-  })
 }
 export default func
 func.tags = ["BTCPoolV2"]


### PR DESCRIPTION
Prevent saving LP token deployment metadata when the pool is already deployed.

Mostly whitespace change and moving the save function into the conditional clause.