### PR TITLE
Allow forking any evm compatible network

### DIFF
--- a/deploy/evmos/999_verify_all_contracts.ts
+++ b/deploy/evmos/999_verify_all_contracts.ts
@@ -3,10 +3,13 @@ import { DeployFunction } from "hardhat-deploy/types"
 import { CHAIN_ID } from "../../utils/network"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { deployments, getChainId } = hre
+  const { deployments, getChainId, network } = hre
   const { log } = deployments
 
-  if ((await getChainId()) === CHAIN_ID.EVMOS_MAINNET) {
+  if (
+    (await getChainId()) === CHAIN_ID.EVMOS_MAINNET &&
+    network.name !== "hardhat"
+  ) {
     await hre.run("etherscan-verify")
   } else {
     log(

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "coverage": "hardhat coverage --temp ./build/artifacts",
     "deploy": "hardhat deploy",
     "start": "hardhat node",
-    "fork": "dotenv -v FORK_MAINNET=true hardhat node --fork \"https://eth-mainnet.alchemyapi.io/v2/${ALCHEMY_API_KEY}\"",
+    "fork:mainnet": "dotenv -v FORK_NETWORK=mainnet hardhat node",
+    "fork:evmos_mainnet": "dotenv -v FORK_NETWORK=evmos_mainnet hardhat node",
     "prepare": "npm run build",
     "addresses": "node scripts/print-addresses.js"
   },

--- a/utils/network.ts
+++ b/utils/network.ts
@@ -1,4 +1,4 @@
-export const CHAIN_ID = {
+export const CHAIN_ID: Record<string, string> = {
   MAINNET: "1",
   ROPSTEN: "3",
   KOVAN: "42",
@@ -11,7 +11,7 @@ export const CHAIN_ID = {
   FANTOM_TESTNET: "4002",
   EVMOS_TESTNET: "9000",
   EVMOS_MAINNET: "9001",
-  KAVA_TESTNET: "2221"
+  KAVA_TESTNET: "2221",
 }
 
 export function isMainnet(networkId: string): boolean {


### PR DESCRIPTION
This will allow attempting to fork any evm compatible network that is in our config. However this is highly dependent on the compatibility between ETH mainnet and the network you are trying to fork. Successful runs are not guaranteed with L2s or sidechains.