### PR TITLE
Deploy SimpleRewarder for tBTC meta pool v3

### DIFF
--- a/deploy/mainnet/492_deploy_SimpleRewarder.ts
+++ b/deploy/mainnet/492_deploy_SimpleRewarder.ts
@@ -1,0 +1,66 @@
+import { expect } from "chai"
+import { BigNumber } from "ethers"
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { CHAIN_ID } from "../../utils/network"
+
+const LP_TOKEN_CONTRACT_NAME = "SaddleTBTCMetaPoolV3LPToken"
+const REWARD_TOKEN_CONTRACT_NAME = "T"
+const SIMPLE_REWARDER_CONTRACT_NAME = "SimpleRewarder"
+const MINICHEFV2_CONTRACT_NAME = "MiniChefV2"
+const NEW_SIMPLE_REWARDER_CONTRACT_NAME = `${SIMPLE_REWARDER_CONTRACT_NAME}_${REWARD_TOKEN_CONTRACT_NAME}_${LP_TOKEN_CONTRACT_NAME}`
+
+const T_TEAM_MULTISIG_ADDRESS = "0xb78c0cf4c9e9bf4ba24b17065fa8c0ac71957653"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId, ethers } = hre
+  const { deploy, execute, get, getOrNull, save, read, log } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  if ((await getChainId()) === CHAIN_ID.HARDHAT) {
+    log(
+      `Running on hardhat. Skipping deploy of ${NEW_SIMPLE_REWARDER_CONTRACT_NAME}`,
+    )
+    return
+  }
+
+  if (!(await getOrNull(NEW_SIMPLE_REWARDER_CONTRACT_NAME))) {
+    await deploy(NEW_SIMPLE_REWARDER_CONTRACT_NAME, {
+      from: deployer,
+      log: true,
+      contract: SIMPLE_REWARDER_CONTRACT_NAME,
+      args: [(await get(MINICHEFV2_CONTRACT_NAME)).address],
+      skipIfAlreadyDeployed: true,
+    })
+
+    const PID = 8
+    const lpToken = (await get(LP_TOKEN_CONTRACT_NAME)).address
+    const rewardToken = (await get(REWARD_TOKEN_CONTRACT_NAME)).address // T token
+    const rewardAdmin = T_TEAM_MULTISIG_ADDRESS // T team's OpEx wallet
+    const rewardPerSecond = BigNumber.from("0") // Let T team handle the rate
+
+    // Ensure pid is correct
+    expect(await read(MINICHEFV2_CONTRACT_NAME, "lpToken", PID)).to.eq(lpToken)
+
+    // (IERC20 rewardToken, address owner, uint256 rewardPerSecond, IERC20 masterLpToken, uint256 pid)
+    const data = ethers.utils.defaultAbiCoder.encode(
+      ["address", "address", "uint256", "address", "uint256"],
+      [
+        rewardToken, // KEEP token
+        rewardAdmin, // KEEP team's OpEx wallet
+        rewardPerSecond, // 250k KEEP weekly
+        lpToken, // master LP token
+        PID, // pid
+      ],
+    )
+
+    await execute(
+      NEW_SIMPLE_REWARDER_CONTRACT_NAME,
+      { from: deployer, log: true },
+      "init",
+      data,
+    )
+  }
+}
+func.skip = async (env) => false
+export default func


### PR DESCRIPTION
# Deploy SimpleRewarder for tBTC meta pool v3

## Description

Deploys a new SimpleRewarder contract for tBTC meta pool v3 LP token. This is to be used with existing MiniChefV2 deployment.

PID: 8


## Deployment checklist

List any new deployments that is expected to be saved after running the deploy task. After running the scripts, check off each item if they are successfully deployed.

- [ ] SimpleRewarder (for tBTC metapool v3 LP token with T rewards)

## Checklist:

- [ ] Any imported tokens's addresses are verified against official docs
- [ ] If any existing contracts are changed, ensure the saved deployments are removed before running the deploy scripts
- [ ] If deploying a new pool on a testnet, ensure there is liquidity by providing the test tokens to a DEX.
- [ ] If possible, the deploy scripts are tested against forked mainnet or local hardhat node.
- [ ] Newly deployed contracts match the expected list of new deployments
- [ ] All newly deployed contracts are verified on explorers