### PR TITLE
Control fork block number using env variable.

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -231,7 +231,15 @@ if (process.env.ACCOUNT_PRIVATE_KEYS) {
 
 if (process.env.FORK_NETWORK && config.networks) {
   const forkNetworkName = process.env.FORK_NETWORK as string
+  const blockNumber = process.env.FORK_BLOCK_NUMBER
+    ? parseInt(process.env.FORK_BLOCK_NUMBER)
+    : undefined
   console.log(`FORK_NETWORK is set to ${forkNetworkName}`)
+  console.log(
+    `FORK_BLOCK_NUMBER is set to ${
+      blockNumber ? blockNumber : "undefined (using latest block number)"
+    }`,
+  )
 
   if (!config.networks[forkNetworkName]) {
     throw new Error(
@@ -266,6 +274,7 @@ if (process.env.FORK_NETWORK && config.networks) {
         ...config.networks.hardhat,
         forking: {
           url: forkingURL,
+          blockNumber: blockNumber,
         },
         chainId: forkingChainId,
         deploy: deployPaths,


### PR DESCRIPTION
if `FORK_BLOCK_NUMBER` is set, use that block number when forking.

If it's not defined, forking will be based on the latest block, which may be slower than forking older blocks.