### PR TITLE
Create a hardhat specific deploy folder.

### DIFF
--- a/deploy/hardhat/000_prepare_network.ts
+++ b/deploy/hardhat/000_prepare_network.ts
@@ -1,0 +1,28 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { isMainnet } from "../../utils/network"
+import dotenv from "dotenv"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId, ethers } = hre
+  const { log } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  dotenv.config()
+
+  if (isMainnet(await getChainId()) && process.env.FORK_MAINNET === "true") {
+    if (
+      process.env.RESET_BASE_FEE_PER_GAS == null ||
+      process.env.RESET_BASE_FEE_PER_GAS === "true"
+    ) {
+      log(`Resetting the base fee per gas to 1 gwei...`)
+      await ethers.provider.send("hardhat_setNextBlockBaseFeePerGas", [
+        "0x3B9ACA00",
+      ])
+    } else {
+      log(`Keeping the base fee per gas...`)
+    }
+  }
+}
+export default func
+func.tags = ["SetupNetwork"]

--- a/deploy/hardhat/001_deploy_Allowlist.ts
+++ b/deploy/hardhat/001_deploy_Allowlist.ts
@@ -1,0 +1,27 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { CHAIN_ID } from "../../utils/network"
+
+const MERKLE_ROOT = {
+  [CHAIN_ID.MAINNET]:
+    "0xc799ec3a26ef7b4c295f6f02d1e6f65c35cef24447ff343076060bfc0eafb24e",
+  [CHAIN_ID.HARDHAT]:
+    "0xca0f8c7ee1addcc5fce6a7c989ba3f210db065c36c276b71b8c8253a339318a3",
+  [CHAIN_ID.ROPSTEN]:
+    "0xca0f8c7ee1addcc5fce6a7c989ba3f210db065c36c276b71b8c8253a339318a3",
+}
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  await deploy("Allowlist", {
+    from: deployer,
+    args: [MERKLE_ROOT[await getChainId()]],
+    log: true,
+    skipIfAlreadyDeployed: true,
+  })
+}
+export default func
+func.tags = ["Allowlist"]

--- a/deploy/hardhat/002_deploy_LPToken.ts
+++ b/deploy/hardhat/002_deploy_LPToken.ts
@@ -1,0 +1,38 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { isTestNetwork } from "../../utils/network"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, execute, getOrNull, log } = deployments
+  const { libraryDeployer } = await getNamedAccounts()
+
+  if (isTestNetwork(await getChainId())) {
+    await deploy("LPTokenV1", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  const lpToken = await getOrNull("LPToken")
+  if (lpToken) {
+    log(`reusing "LPToken" at ${lpToken.address}`)
+  } else {
+    await deploy("LPToken", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+
+    await execute(
+      "LPToken",
+      { from: libraryDeployer, log: true },
+      "initialize",
+      "Saddle LP Token (Target)",
+      "saddleLPTokenTarget",
+    )
+  }
+}
+export default func
+func.tags = ["LPToken"]

--- a/deploy/hardhat/003_deploy_AmplificationUtils.ts
+++ b/deploy/hardhat/003_deploy_AmplificationUtils.ts
@@ -1,0 +1,25 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { isTestNetwork } from "../../utils/network"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy } = deployments
+  const { libraryDeployer } = await getNamedAccounts()
+
+  if (isTestNetwork(await getChainId())) {
+    await deploy("AmplificationUtilsV1", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  await deploy("AmplificationUtils", {
+    from: libraryDeployer,
+    log: true,
+    skipIfAlreadyDeployed: true,
+  })
+}
+export default func
+func.tags = ["AmplificationUtils"]

--- a/deploy/hardhat/003_deploy_SwapUtilsGuarded.ts
+++ b/deploy/hardhat/003_deploy_SwapUtilsGuarded.ts
@@ -1,0 +1,16 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { deploy, get } = deployments
+  const { libraryDeployer } = await getNamedAccounts()
+
+  await deploy("SwapUtilsGuarded", {
+    from: libraryDeployer,
+    log: true,
+    skipIfAlreadyDeployed: true,
+  })
+}
+export default func
+func.tags = ["SwapUtilsGuarded"]

--- a/deploy/hardhat/004_deploy_MetaSwapUtils.ts
+++ b/deploy/hardhat/004_deploy_MetaSwapUtils.ts
@@ -1,0 +1,16 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { deploy, get } = deployments
+  const { libraryDeployer } = await getNamedAccounts()
+
+  await deploy("MetaSwapUtils", {
+    from: libraryDeployer,
+    log: true,
+    skipIfAlreadyDeployed: true,
+  })
+}
+export default func
+func.tags = ["MetaSwapUtils"]

--- a/deploy/hardhat/004_deploy_SwapUtils.ts
+++ b/deploy/hardhat/004_deploy_SwapUtils.ts
@@ -1,0 +1,25 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { isTestNetwork } from "../../utils/network"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, get } = deployments
+  const { libraryDeployer } = await getNamedAccounts()
+
+  if (isTestNetwork(await getChainId())) {
+    await deploy("SwapUtilsV1", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  await deploy("SwapUtils", {
+    from: libraryDeployer,
+    log: true,
+    skipIfAlreadyDeployed: true,
+  })
+}
+export default func
+func.tags = ["SwapUtils"]

--- a/deploy/hardhat/005_deploy_SwapDeployer.ts
+++ b/deploy/hardhat/005_deploy_SwapDeployer.ts
@@ -1,0 +1,38 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { isMainnet, isTestNetwork } from "../../utils/network"
+import { MULTISIG_ADDRESSES } from "../../utils/accounts"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, execute, read } = deployments
+  const { deployer, libraryDeployer } = await getNamedAccounts()
+
+  if (isTestNetwork(await getChainId())) {
+    await deploy("SwapDeployerV1", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  await deploy("SwapDeployer", {
+    from: deployer,
+    log: true,
+    skipIfAlreadyDeployed: true,
+  })
+
+  const currentOwner = await read("SwapDeployer", "owner")
+  const chainId = await getChainId()
+
+  if (isMainnet(chainId) && currentOwner != MULTISIG_ADDRESSES[chainId]) {
+    await execute(
+      "SwapDeployer",
+      { from: deployer, log: true },
+      "transferOwnership",
+      MULTISIG_ADDRESSES[chainId],
+    )
+  }
+}
+export default func
+func.tags = ["SwapDeployer"]

--- a/deploy/hardhat/006_deploy_Swap.ts
+++ b/deploy/hardhat/006_deploy_Swap.ts
@@ -1,0 +1,34 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { isTestNetwork } from "../../utils/network"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, get } = deployments
+  const { libraryDeployer } = await getNamedAccounts()
+
+  if (isTestNetwork(await getChainId())) {
+    await deploy("SwapV1", {
+      from: libraryDeployer,
+      log: true,
+      libraries: {
+        SwapUtilsV1: (await get("SwapUtilsV1")).address,
+        AmplificationUtilsV1: (await get("AmplificationUtilsV1")).address,
+      },
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  await deploy("Swap", {
+    from: libraryDeployer,
+    log: true,
+    libraries: {
+      SwapUtils: (await get("SwapUtils")).address,
+      AmplificationUtils: (await get("AmplificationUtils")).address,
+    },
+    skipIfAlreadyDeployed: true,
+  })
+}
+export default func
+func.tags = ["Swap"]
+func.dependencies = ["AmplificationUtils", "SwapUtils"]

--- a/deploy/hardhat/006_deploy_SwapFlashLoan.ts
+++ b/deploy/hardhat/006_deploy_SwapFlashLoan.ts
@@ -1,0 +1,34 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { isTestNetwork } from "../../utils/network"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, get } = deployments
+  const { libraryDeployer } = await getNamedAccounts()
+
+  if (isTestNetwork(await getChainId())) {
+    await deploy("SwapFlashLoanV1", {
+      from: libraryDeployer,
+      log: true,
+      libraries: {
+        SwapUtilsV1: (await get("SwapUtilsV1")).address,
+        AmplificationUtilsV1: (await get("AmplificationUtilsV1")).address,
+      },
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  await deploy("SwapFlashLoan", {
+    from: libraryDeployer,
+    log: true,
+    libraries: {
+      SwapUtils: (await get("SwapUtils")).address,
+      AmplificationUtils: (await get("AmplificationUtils")).address,
+    },
+    skipIfAlreadyDeployed: true,
+  })
+}
+export default func
+func.tags = ["SwapFlashLoan"]
+func.dependencies = ["AmplificationUtils", "SwapUtils", "LPToken"]

--- a/deploy/hardhat/100_check_BTCPoolTokens.ts
+++ b/deploy/hardhat/100_check_BTCPoolTokens.ts
@@ -1,0 +1,40 @@
+import { BigNumber } from "ethers"
+import { isTestNetwork } from "../../utils/network"
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+
+const BTC_TOKENS_ARGS: { [token: string]: any[] } = {
+  TBTC: ["tBTC", "TBTC", "18"],
+  WBTC: ["Wrapped Bitcoin", "WBTC", "8"],
+  RENBTC: ["renBTC", "RENBTC", "8"],
+  SBTC: ["sBTC", "SBTC", "18"],
+}
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, execute } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  for (const token in BTC_TOKENS_ARGS) {
+    await deploy(token, {
+      from: deployer,
+      log: true,
+      contract: "GenericERC20",
+      args: BTC_TOKENS_ARGS[token],
+      skipIfAlreadyDeployed: true,
+    })
+    // If it's on hardhat, mint test tokens
+    if (isTestNetwork(await getChainId())) {
+      const decimals = BTC_TOKENS_ARGS[token][2]
+      await execute(
+        token,
+        { from: deployer, log: true },
+        "mint",
+        deployer,
+        BigNumber.from(10).pow(decimals).mul(10000),
+      )
+    }
+  }
+}
+export default func
+func.tags = ["BTCPoolTokens"]

--- a/deploy/hardhat/101_deploy_BTCPool.ts
+++ b/deploy/hardhat/101_deploy_BTCPool.ts
@@ -1,0 +1,61 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { deploy, get, log, read, save, getOrNull } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Constructor arguments
+  const TOKEN_ADDRESSES = [
+    (await get("TBTC")).address,
+    (await get("WBTC")).address,
+    (await get("RENBTC")).address,
+    (await get("SBTC")).address,
+  ]
+  const TOKEN_DECIMALS = [18, 8, 8, 18]
+  const LP_TOKEN_NAME = "Saddle tBTC/WBTC/renBTC/sBTC"
+  const LP_TOKEN_SYMBOL = "saddleTWRenSBTC"
+  const INITIAL_A = 200
+  const SWAP_FEE = 4e6 // 4bps
+  const ADMIN_FEE = 0
+  const WITHDRAW_FEE = 0
+  const ALLOWLIST_ADDRESS = (await get("Allowlist")).address
+
+  const poolDeployment = await getOrNull("SaddleBTCPool")
+  if (poolDeployment) {
+    log(`reusing SaddleBTCPool at ${poolDeployment.address}`)
+  } else {
+    await deploy("SaddleBTCPool", {
+      from: deployer,
+      log: true,
+      contract: "SwapGuarded",
+      libraries: {
+        SwapUtilsGuarded: (await get("SwapUtilsGuarded")).address,
+      },
+      args: [
+        TOKEN_ADDRESSES,
+        TOKEN_DECIMALS,
+        LP_TOKEN_NAME,
+        LP_TOKEN_SYMBOL,
+        INITIAL_A,
+        SWAP_FEE, // 4bps
+        ADMIN_FEE,
+        WITHDRAW_FEE,
+        ALLOWLIST_ADDRESS,
+      ],
+      skipIfAlreadyDeployed: true,
+    })
+
+    const lpTokenAddress = (await read("SaddleBTCPool", "swapStorage")).lpToken
+    log(`BTC pool LP Token at ${lpTokenAddress}`)
+
+    await save("SaddleBTCPoolLPToken", {
+      abi: (await get("TBTC")).abi, // Generic ERC20 ABI
+      address: lpTokenAddress,
+    })
+  }
+}
+export default func
+func.tags = ["BTCPool"]
+func.dependencies = ["Allowlist", "SwapUtilsGuarded", "BTCPoolTokens"]

--- a/deploy/hardhat/102_disable_guard_BTCPool.ts
+++ b/deploy/hardhat/102_disable_guard_BTCPool.ts
@@ -1,0 +1,29 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, log, read } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const currentOwner = await read("SaddleBTCPool", "owner")
+  const isBTCPoolGuarded = await read("SaddleBTCPool", "isGuarded")
+
+  // Disable the guarded phase launch
+  if (isBTCPoolGuarded) {
+    if (currentOwner == deployer) {
+      log(`disabling BTC pool guard from deployer ${deployer}`)
+      await execute(
+        "SaddleBTCPool",
+        { from: deployer, log: true },
+        "disableGuard",
+      )
+    } else {
+      log(`cannot disable BTC pool guard. owner is set to ${currentOwner}`)
+    }
+  } else {
+    log(`btc pool guard is already disabled`)
+  }
+}
+export default func
+func.dependencies = ["BTCPool"]

--- a/deploy/hardhat/110_check_USDPoolTokens.ts
+++ b/deploy/hardhat/110_check_USDPoolTokens.ts
@@ -1,0 +1,39 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { isTestNetwork } from "../../utils/network"
+import { BigNumber } from "ethers"
+
+const USD_TOKENS_ARGS: { [token: string]: any[] } = {
+  DAI: ["Dai Stablecoin", "DAI", "18"],
+  USDC: ["USD Coin", "USDC", "6"],
+  USDT: ["Tether USD", "USDT", "6"],
+}
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, execute } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  for (const token in USD_TOKENS_ARGS) {
+    await deploy(token, {
+      from: deployer,
+      log: true,
+      contract: "GenericERC20",
+      args: USD_TOKENS_ARGS[token],
+      skipIfAlreadyDeployed: true,
+    })
+    // If it's on hardhat, mint test tokens
+    if (isTestNetwork(await getChainId())) {
+      const decimals = USD_TOKENS_ARGS[token][2]
+      await execute(
+        token,
+        { from: deployer, log: true },
+        "mint",
+        deployer,
+        BigNumber.from(10).pow(decimals).mul(1000000),
+      )
+    }
+  }
+}
+export default func
+func.tags = ["USDPoolTokens"]

--- a/deploy/hardhat/111_deploy_USDPool.ts
+++ b/deploy/hardhat/111_deploy_USDPool.ts
@@ -1,0 +1,76 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, get, getOrNull, log, read, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const saddleUSDPool = await getOrNull("SaddleUSDPool")
+  if (saddleUSDPool) {
+    log(`reusing "SaddleUSDPool" at ${saddleUSDPool.address}`)
+  } else {
+    // Constructor arguments
+    const TOKEN_ADDRESSES = [
+      (await get("DAI")).address,
+      (await get("USDC")).address,
+      (await get("USDT")).address,
+    ]
+    const TOKEN_DECIMALS = [18, 6, 6]
+    const LP_TOKEN_NAME = "Saddle DAI/USDC/USDT"
+    const LP_TOKEN_SYMBOL = "saddleUSD"
+    const INITIAL_A = 200
+    const SWAP_FEE = 4e6 // 4bps
+    const ADMIN_FEE = 0
+    const WITHDRAW_FEE = 0
+
+    const receipt = await execute(
+      "SwapDeployerV1",
+      { from: deployer, log: true },
+      "deploy",
+      (
+        await get("SwapFlashLoanV1")
+      ).address,
+      TOKEN_ADDRESSES,
+      TOKEN_DECIMALS,
+      LP_TOKEN_NAME,
+      LP_TOKEN_SYMBOL,
+      INITIAL_A,
+      SWAP_FEE,
+      ADMIN_FEE,
+      WITHDRAW_FEE,
+      (
+        await get("LPTokenV1")
+      ).address,
+    )
+
+    const newPoolEvent = receipt?.events?.find(
+      (e: any) => e["event"] == "NewSwapPool",
+    )
+    const usdSwapAddress = newPoolEvent["args"]["swapAddress"]
+    log(
+      `deployed USD pool clone (targeting "SwapFlashLoanV1") at ${usdSwapAddress}`,
+    )
+    await save("SaddleUSDPool", {
+      abi: (await get("SwapFlashLoanV1")).abi,
+      address: usdSwapAddress,
+    })
+
+    const lpTokenAddress = (await read("SaddleUSDPool", "swapStorage")).lpToken
+    log(`USD pool LP Token at ${lpTokenAddress}`)
+
+    await save("SaddleUSDPoolLPToken", {
+      abi: (await get("TBTC")).abi, // Generic ERC20 ABI
+      address: lpTokenAddress,
+    })
+  }
+}
+export default func
+func.tags = ["USDPool"]
+func.dependencies = [
+  "SwapUtils",
+  "SwapDeployer",
+  "SwapFlashLoan",
+  "USDPoolTokens",
+]

--- a/deploy/hardhat/120_check_VETHPoolTokens.ts
+++ b/deploy/hardhat/120_check_VETHPoolTokens.ts
@@ -1,0 +1,38 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { isTestNetwork } from "../../utils/network"
+import { BigNumber } from "ethers"
+
+const VETH2_TOKENS_ARGS: { [token: string]: any[] } = {
+  WETH: ["Wrapped Ether", "WETH", "18"],
+  VETH2: ["validator-Eth2", "vETH2", "18"],
+}
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, execute } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  for (const token in VETH2_TOKENS_ARGS) {
+    await deploy(token, {
+      from: deployer,
+      log: true,
+      contract: "GenericERC20",
+      args: VETH2_TOKENS_ARGS[token],
+      skipIfAlreadyDeployed: true,
+    })
+    // If it's on hardhat, mint test tokens
+    if (isTestNetwork(await getChainId())) {
+      const decimals = VETH2_TOKENS_ARGS[token][2]
+      await execute(
+        token,
+        { from: deployer, log: true },
+        "mint",
+        deployer,
+        BigNumber.from(10).pow(decimals).mul(1000),
+      )
+    }
+  }
+}
+export default func
+func.tags = ["VETH2PoolTokens"]

--- a/deploy/hardhat/121_deploy_VETH2Pool.ts
+++ b/deploy/hardhat/121_deploy_VETH2Pool.ts
@@ -1,0 +1,76 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, get, getOrNull, log, read, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const saddleVETH2Pool = await getOrNull("SaddleVETH2Pool")
+  if (saddleVETH2Pool) {
+    log(`reusing "SaddleVETH2Pool" at ${saddleVETH2Pool.address}`)
+  } else {
+    // Constructor arguments
+    const TOKEN_ADDRESSES = [
+      (await get("WETH")).address,
+      (await get("VETH2")).address,
+    ]
+    const TOKEN_DECIMALS = [18, 18]
+    const LP_TOKEN_NAME = "Saddle WETH/vETH2"
+    const LP_TOKEN_SYMBOL = "saddleVETH2"
+    const INITIAL_A = 10
+    const SWAP_FEE = 4e6 // 4bps
+    const ADMIN_FEE = 0
+    const WITHDRAW_FEE = 0
+
+    const receipt = await execute(
+      "SwapDeployerV1",
+      { from: deployer, log: true },
+      "deploy",
+      (
+        await get("SwapFlashLoanV1")
+      ).address,
+      TOKEN_ADDRESSES,
+      TOKEN_DECIMALS,
+      LP_TOKEN_NAME,
+      LP_TOKEN_SYMBOL,
+      INITIAL_A,
+      SWAP_FEE,
+      ADMIN_FEE,
+      WITHDRAW_FEE,
+      (
+        await get("LPTokenV1")
+      ).address,
+    )
+
+    const newPoolEvent = receipt?.events?.find(
+      (e: any) => e["event"] == "NewSwapPool",
+    )
+    const veth2SwapAddress = newPoolEvent["args"]["swapAddress"]
+    log(
+      `deployed vETH2 pool (targeting "SwapFlashLoanV1") at ${veth2SwapAddress}`,
+    )
+    await save("SaddleVETH2Pool", {
+      abi: (await get("SwapFlashLoanV1")).abi,
+      address: veth2SwapAddress,
+    })
+
+    const lpTokenAddress = (await read("SaddleVETH2Pool", "swapStorage"))
+      .lpToken
+    log(`vETH2 pool LP Token at ${lpTokenAddress}`)
+
+    await save("SaddleVETH2PoolLPToken", {
+      abi: (await get("TBTC")).abi, // Generic ERC20 ABI
+      address: lpTokenAddress,
+    })
+  }
+}
+export default func
+func.tags = ["VETH2Pool"]
+func.dependencies = [
+  "SwapUtils",
+  "SwapDeployer",
+  "SwapFlashLoan",
+  "VETH2PoolTokens",
+]

--- a/deploy/hardhat/130_deploy_Multicall.ts
+++ b/deploy/hardhat/130_deploy_Multicall.ts
@@ -1,0 +1,48 @@
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { CHAIN_ID } from "../../utils/network"
+import { impersonateAccount } from "../../test/testUtils"
+import { ethers } from "hardhat"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  await deploy("Multicall", {
+    from: deployer,
+    log: true,
+    skipIfAlreadyDeployed: true,
+  })
+
+  await deploy("Multicall2", {
+    from: deployer,
+    log: true,
+    skipIfAlreadyDeployed: true,
+  })
+
+  if ((await getChainId()) == CHAIN_ID.HARDHAT) {
+    const contractOwnerAddress = "0x05f32b3cc3888453ff71b01135b34ff8e41263f2"
+    const impersonatedOwner = await impersonateAccount(contractOwnerAddress)
+    await hre.network.provider.send("hardhat_setBalance", [
+      await impersonatedOwner.getAddress(),
+      `0x${(1e18).toString(16)}`,
+    ])
+
+    const Multicall3 = await ethers.getContractFactory(
+      "Multicall3",
+      impersonatedOwner,
+    )
+
+    const multicall3 = await Multicall3.deploy()
+    await multicall3.deployed()
+
+    await save("Multicall3", {
+      abi: multicall3.abi,
+      address: multicall3.address,
+    })
+  }
+}
+
+export default func
+func.tags = ["Multicall"]

--- a/deploy/hardhat/140_check_alETHPoolTokens.ts
+++ b/deploy/hardhat/140_check_alETHPoolTokens.ts
@@ -1,0 +1,39 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { isTestNetwork } from "../../utils/network"
+import { BigNumber } from "ethers"
+
+const ALETH_TOKENS_ARGS: { [token: string]: any[] } = {
+  WETH: ["Wrapped Ether", "WETH", "18"],
+  ALETH: ["Alchemix ETH", "alETH", "18"],
+  SETH: ["Synthetic ETH", "sETH", "18"],
+}
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, execute } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  for (const token in ALETH_TOKENS_ARGS) {
+    await deploy(token, {
+      from: deployer,
+      log: true,
+      contract: "GenericERC20",
+      args: ALETH_TOKENS_ARGS[token],
+      skipIfAlreadyDeployed: true,
+    })
+    // If it's on hardhat, mint test tokens
+    if (isTestNetwork(await getChainId())) {
+      const decimals = ALETH_TOKENS_ARGS[token][2]
+      await execute(
+        token,
+        { from: deployer, log: true },
+        "mint",
+        deployer,
+        BigNumber.from(10).pow(decimals).mul(1000),
+      )
+    }
+  }
+}
+export default func
+func.tags = ["ALETHPoolTokens"]

--- a/deploy/hardhat/140_deploy_alETHPool.ts
+++ b/deploy/hardhat/140_deploy_alETHPool.ts
@@ -1,0 +1,75 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, get, getOrNull, log, read, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const SaddleALETHPool = await getOrNull("SaddleALETHPool")
+  if (SaddleALETHPool) {
+    log(`reusing "SaddleALETHPool" at ${SaddleALETHPool.address}`)
+  } else {
+    // Constructor arguments
+    const TOKEN_ADDRESSES = [
+      (await get("WETH")).address,
+      (await get("ALETH")).address,
+      (await get("SETH")).address,
+    ]
+    const TOKEN_DECIMALS = [18, 18, 18]
+    const LP_TOKEN_NAME = "Saddle WETH/alETH/sETH"
+    const LP_TOKEN_SYMBOL = "saddlealETH"
+    const INITIAL_A = 60
+    const SWAP_FEE = 4e6 // 4bps
+    const ADMIN_FEE = 0
+
+    const receipt = await execute(
+      "SwapDeployer",
+      { from: deployer, log: true },
+      "deploy",
+      (
+        await get("SwapFlashLoan")
+      ).address,
+      TOKEN_ADDRESSES,
+      TOKEN_DECIMALS,
+      LP_TOKEN_NAME,
+      LP_TOKEN_SYMBOL,
+      INITIAL_A,
+      SWAP_FEE,
+      ADMIN_FEE,
+      (
+        await get("LPToken")
+      ).address,
+    )
+
+    const newPoolEvent = receipt?.events?.find(
+      (e: any) => e["event"] == "NewSwapPool",
+    )
+    const alETHSwapAddress = newPoolEvent["args"]["swapAddress"]
+    log(
+      `deployed alETH pool (targeting "SwapFlashLoan") at ${alETHSwapAddress}`,
+    )
+    await save("SaddleALETHPool", {
+      abi: (await get("SwapFlashLoan")).abi,
+      address: alETHSwapAddress,
+    })
+
+    const lpTokenAddress = (await read("SaddleALETHPool", "swapStorage"))
+      .lpToken
+    log(`alETH pool LP Token at ${lpTokenAddress}`)
+
+    await save("SaddleALETHPoolLPToken", {
+      abi: (await get("TBTC")).abi, // Generic ERC20 ABI
+      address: lpTokenAddress,
+    })
+  }
+}
+export default func
+func.tags = ["ALETHPool"]
+func.dependencies = [
+  "SwapUtils",
+  "SwapDeployer",
+  "SwapFlashLoan",
+  "ALETHPoolTokens",
+]

--- a/deploy/hardhat/150_check_D4PoolTokens.ts
+++ b/deploy/hardhat/150_check_D4PoolTokens.ts
@@ -1,0 +1,40 @@
+import { BigNumber } from "ethers"
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { isTestNetwork } from "../../utils/network"
+
+const D4_TOKENS_ARGS: { [token: string]: any[] } = {
+  ALUSD: ["Alchemix USD", "alUSD", "18"],
+  FEI: ["Fei Protocol", "FEI", "18"],
+  FRAX: ["Frax", "FRAX", "18"],
+  LUSD: ["Liquity USD", "LUSD", "18"],
+}
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, execute } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  for (const token in D4_TOKENS_ARGS) {
+    await deploy(token, {
+      from: deployer,
+      log: true,
+      contract: "GenericERC20",
+      args: D4_TOKENS_ARGS[token],
+      skipIfAlreadyDeployed: true,
+    })
+    // If it's on hardhat, mint test tokens
+    if (isTestNetwork(await getChainId())) {
+      const decimals = D4_TOKENS_ARGS[token][2]
+      await execute(
+        token,
+        { from: deployer, log: true },
+        "mint",
+        deployer,
+        BigNumber.from(10).pow(decimals).mul(1000),
+      )
+    }
+  }
+}
+export default func
+func.tags = ["D4PoolTokens"]

--- a/deploy/hardhat/150_deploy_D4Pool.ts
+++ b/deploy/hardhat/150_deploy_D4Pool.ts
@@ -1,0 +1,73 @@
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, get, getOrNull, log, read, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const SaddleD4Pool = await getOrNull("SaddleD4Pool")
+  if (SaddleD4Pool) {
+    log(`reusing "SaddleD4Pool" at ${SaddleD4Pool.address}`)
+  } else {
+    // Constructor arguments
+    const TOKEN_ADDRESSES = [
+      (await get("ALUSD")).address,
+      (await get("FEI")).address,
+      (await get("FRAX")).address,
+      (await get("LUSD")).address,
+    ]
+    const TOKEN_DECIMALS = [18, 18, 18, 18]
+    const LP_TOKEN_NAME = "Saddle alUSD/FEI/FRAX/LUSD"
+    const LP_TOKEN_SYMBOL = "saddleD4"
+    const INITIAL_A = 60
+    const SWAP_FEE = 4e6 // 4bps
+    const ADMIN_FEE = 0
+
+    const receipt = await execute(
+      "SwapDeployer",
+      { from: deployer, log: true },
+      "deploy",
+      (
+        await get("SwapFlashLoan")
+      ).address,
+      TOKEN_ADDRESSES,
+      TOKEN_DECIMALS,
+      LP_TOKEN_NAME,
+      LP_TOKEN_SYMBOL,
+      INITIAL_A,
+      SWAP_FEE,
+      ADMIN_FEE,
+      (
+        await get("LPToken")
+      ).address,
+    )
+
+    const newPoolEvent = receipt?.events?.find(
+      (e: any) => e["event"] == "NewSwapPool",
+    )
+    const D4SwapAddress = newPoolEvent["args"]["swapAddress"]
+    log(`deployed D4 pool (targeting "SwapFlashLoan") at ${D4SwapAddress}`)
+    await save("SaddleD4Pool", {
+      abi: (await get("SwapFlashLoan")).abi,
+      address: D4SwapAddress,
+    })
+
+    const lpTokenAddress = (await read("SaddleD4Pool", "swapStorage")).lpToken
+    log(`D4 pool LP Token at ${lpTokenAddress}`)
+
+    await save("SaddleD4PoolLPToken", {
+      abi: (await get("TBTC")).abi, // Generic ERC20 ABI
+      address: lpTokenAddress,
+    })
+  }
+}
+export default func
+func.tags = ["D4Pool"]
+func.dependencies = [
+  "SwapUtils",
+  "SwapDeployer",
+  "SwapFlashLoan",
+  "D4PoolTokens",
+]

--- a/deploy/hardhat/160_deploy_USDPoolV2.ts
+++ b/deploy/hardhat/160_deploy_USDPoolV2.ts
@@ -1,0 +1,73 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, get, getOrNull, log, read, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const SaddleUSDPoolV2 = await getOrNull("SaddleUSDPoolV2")
+  if (SaddleUSDPoolV2) {
+    log(`reusing "SaddleUSDPoolV2" at ${SaddleUSDPoolV2.address}`)
+  } else {
+    // Constructor arguments
+    const TOKEN_ADDRESSES = [
+      (await get("DAI")).address,
+      (await get("USDC")).address,
+      (await get("USDT")).address,
+    ]
+    const TOKEN_DECIMALS = [18, 6, 6]
+    const LP_TOKEN_NAME = "Saddle DAI/USDC/USDT V2"
+    const LP_TOKEN_SYMBOL = "saddleUSD-V2"
+    const INITIAL_A = 200
+    const SWAP_FEE = 4e6 // 4bps
+    const ADMIN_FEE = 0
+
+    const receipt = await execute(
+      "SwapDeployer",
+      { from: deployer, log: true },
+      "deploy",
+      (
+        await get("SwapFlashLoan")
+      ).address,
+      TOKEN_ADDRESSES,
+      TOKEN_DECIMALS,
+      LP_TOKEN_NAME,
+      LP_TOKEN_SYMBOL,
+      INITIAL_A,
+      SWAP_FEE,
+      ADMIN_FEE,
+      (
+        await get("LPToken")
+      ).address,
+    )
+
+    const newPoolEvent = receipt?.events?.find(
+      (e: any) => e["event"] == "NewSwapPool",
+    )
+    const usdSwapAddress = newPoolEvent["args"]["swapAddress"]
+    log(`deployed USD pool V2 (targeting "SwapFlashLoan") at ${usdSwapAddress}`)
+    await save("SaddleUSDPoolV2", {
+      abi: (await get("SwapFlashLoan")).abi,
+      address: usdSwapAddress,
+    })
+
+    const lpTokenAddress = (await read("SaddleUSDPoolV2", "swapStorage"))
+      .lpToken
+    log(`USD pool V2 LP Token at ${lpTokenAddress}`)
+
+    await save("SaddleUSDPoolV2LPToken", {
+      abi: (await get("LPToken")).abi, // LPToken ABI
+      address: lpTokenAddress,
+    })
+  }
+}
+export default func
+func.tags = ["USDPoolV2"]
+func.dependencies = [
+  "SwapUtils",
+  "SwapDeployer",
+  "SwapFlashLoan",
+  "USDPoolTokens",
+]

--- a/deploy/hardhat/170_deploy_SwapMigrator.ts
+++ b/deploy/hardhat/170_deploy_SwapMigrator.ts
@@ -1,0 +1,41 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { MULTISIG_ADDRESSES } from "../../utils/accounts"
+import { isTestNetwork } from "../../utils/network"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { get, deploy } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const oldUSDPool = await get("SaddleUSDPool")
+  const oldUSDPoolLPToken = await get("SaddleUSDPoolLPToken")
+  const newUSDPool = await get("SaddleUSDPoolV2")
+  const newUSDPoolLPToken = await get("SaddleUSDPoolV2LPToken")
+
+  const DAI = await get("DAI")
+  const USDC = await get("USDC")
+  const USDT = await get("USDT")
+
+  const usdDataStruct = {
+    oldPoolAddress: oldUSDPool.address,
+    oldPoolLPTokenAddress: oldUSDPoolLPToken.address,
+    newPoolAddress: newUSDPool.address,
+    newPoolLPTokenAddress: newUSDPoolLPToken.address,
+    underlyingTokens: [DAI.address, USDC.address, USDT.address],
+  }
+
+  const owner = isTestNetwork(await getChainId())
+    ? deployer
+    : MULTISIG_ADDRESSES[await getChainId()]
+
+  await deploy("SwapMigrator", {
+    from: deployer,
+    log: true,
+    skipIfAlreadyDeployed: true,
+    args: [usdDataStruct, owner],
+  })
+}
+export default func
+func.tags = ["SwapMigrator"]
+func.dependencies = ["USDPoolV2"]

--- a/deploy/hardhat/180_check_SUSDMetaPoolTokens.ts
+++ b/deploy/hardhat/180_check_SUSDMetaPoolTokens.ts
@@ -1,0 +1,38 @@
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { isTestNetwork } from "../../utils/network"
+import { BigNumber } from "ethers"
+
+const USD_TOKENS_ARGS: { [token: string]: any[] } = {
+  SUSD: ["Synth sUSD", "sUSD", "18"],
+}
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, execute } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  for (const token in USD_TOKENS_ARGS) {
+    await deploy(token, {
+      from: deployer,
+      log: true,
+      contract: "GenericERC20",
+      args: USD_TOKENS_ARGS[token],
+      skipIfAlreadyDeployed: true,
+    })
+    // If it's on hardhat, mint test tokens
+    if (isTestNetwork(await getChainId())) {
+      const decimals = USD_TOKENS_ARGS[token][2]
+      await execute(
+        token,
+        { from: deployer, log: true },
+        "mint",
+        deployer,
+        BigNumber.from(10).pow(decimals).mul(1000000),
+      )
+    }
+  }
+}
+export default func
+func.tags = ["SUSDMetaPoolTokens"]
+func.dependencies = ["USDPoolV2"]

--- a/deploy/hardhat/181_deploy_SUSDMetaPool.ts
+++ b/deploy/hardhat/181_deploy_SUSDMetaPool.ts
@@ -1,0 +1,88 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { MULTISIG_ADDRESSES } from "../../utils/accounts"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { execute, deploy, get, getOrNull, log, read, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const saddleSUSDMetaPool = await getOrNull("SaddleSUSDMetaPool")
+  if (saddleSUSDMetaPool) {
+    log(`reusing "SaddleSUSDMetaPool" at ${saddleSUSDMetaPool.address}`)
+  } else {
+    // Constructor arguments
+    const TOKEN_ADDRESSES = [
+      (await get("SUSD")).address,
+      (await get("SaddleUSDPoolV2LPToken")).address,
+    ]
+    const TOKEN_DECIMALS = [18, 18]
+    const LP_TOKEN_NAME = "Saddle sUSD/saddleUSD-V2"
+    const LP_TOKEN_SYMBOL = "saddleSUSD"
+    const INITIAL_A = 100
+    const SWAP_FEE = 4e6 // 4bps
+    const ADMIN_FEE = 0
+
+    await deploy("SaddleSUSDMetaPool", {
+      from: deployer,
+      log: true,
+      contract: "MetaSwap",
+      skipIfAlreadyDeployed: true,
+      libraries: {
+        SwapUtils: (await get("SwapUtils")).address,
+        MetaSwapUtils: (await get("MetaSwapUtils")).address,
+        AmplificationUtils: (await get("AmplificationUtils")).address,
+      },
+    })
+
+    // Save the first deployment as MetaSwapUpdated
+    await save("MetaSwap", await get("SaddleSUSDMetaPool"))
+
+    await execute(
+      "SaddleSUSDMetaPool",
+      {
+        from: deployer,
+        log: true,
+      },
+      "initializeMetaSwap",
+      TOKEN_ADDRESSES,
+      TOKEN_DECIMALS,
+      LP_TOKEN_NAME,
+      LP_TOKEN_SYMBOL,
+      INITIAL_A,
+      SWAP_FEE,
+      ADMIN_FEE,
+      (
+        await get("LPToken")
+      ).address,
+      (
+        await get("SaddleUSDPoolV2")
+      ).address,
+    )
+
+    await execute(
+      "SaddleSUSDMetaPool",
+      { from: deployer, log: true },
+      "transferOwnership",
+      MULTISIG_ADDRESSES[await getChainId()],
+    )
+
+    const lpTokenAddress = (await read("SaddleSUSDMetaPool", "swapStorage"))
+      .lpToken
+    log(`Saddle sUSD MetaSwap LP Token at ${lpTokenAddress}`)
+
+    await save("SaddleSUSDMetaPoolLPToken", {
+      abi: (await get("LPToken")).abi, // LPToken ABI
+      address: lpTokenAddress,
+    })
+  }
+}
+export default func
+func.tags = ["SUSDMetaPool"]
+func.dependencies = [
+  "SUSDMetaPoolTokens",
+  "USDPoolV2",
+  "MetaSwapUtils",
+  "AmplificationUtils",
+]

--- a/deploy/hardhat/182_deploy_SUSDMetaPoolDeposit.ts
+++ b/deploy/hardhat/182_deploy_SUSDMetaPoolDeposit.ts
@@ -1,0 +1,43 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, deploy, get, getOrNull, log, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const saddleSUSDMetaPool = await getOrNull("SaddleSUSDMetaPoolDeposit")
+  if (saddleSUSDMetaPool) {
+    log(`reusing "SaddleSUSDMetaPoolDeposit" at ${saddleSUSDMetaPool.address}`)
+  } else {
+    const result = await deploy("SaddleSUSDMetaPoolDeposit", {
+      from: deployer,
+      log: true,
+      contract: "MetaSwapDeposit",
+      skipIfAlreadyDeployed: true,
+    })
+
+    await execute(
+      "SaddleSUSDMetaPoolDeposit",
+      { from: deployer, log: true },
+      "initialize",
+      (
+        await get("SaddleUSDPoolV2")
+      ).address,
+      (
+        await get("SaddleSUSDMetaPool")
+      ).address,
+      (
+        await get("SaddleSUSDMetaPoolLPToken")
+      ).address,
+    )
+
+    if (!(await getOrNull("MetaSwapDeposit"))) {
+      await save("MetaSwapDeposit", result)
+    }
+  }
+}
+export default func
+func.tags = ["SUSDMetaPoolDeposit"]
+func.dependencies = ["SUSDMetaPoolTokens", "SUSDMetaPool"]

--- a/deploy/hardhat/190_check_BTCPoolV2Tokens.ts
+++ b/deploy/hardhat/190_check_BTCPoolV2Tokens.ts
@@ -1,0 +1,39 @@
+import { BigNumber } from "ethers"
+import { isTestNetwork } from "../../utils/network"
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+
+const BTC_TOKENS_ARGS: { [token: string]: any[] } = {
+  WBTC: ["Wrapped Bitcoin", "WBTC", "8"],
+  RENBTC: ["renBTC", "RENBTC", "8"],
+  SBTC: ["sBTC", "SBTC", "18"],
+}
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, execute } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  for (const token in BTC_TOKENS_ARGS) {
+    await deploy(token, {
+      from: deployer,
+      log: true,
+      contract: "GenericERC20",
+      args: BTC_TOKENS_ARGS[token],
+      skipIfAlreadyDeployed: true,
+    })
+    // If it's on hardhat, mint test tokens
+    if (isTestNetwork(await getChainId())) {
+      const decimals = BTC_TOKENS_ARGS[token][2]
+      await execute(
+        token,
+        { from: deployer, log: true },
+        "mint",
+        deployer,
+        BigNumber.from(10).pow(decimals).mul(10000),
+      )
+    }
+  }
+}
+export default func
+func.tags = ["BTCPoolV2Tokens"]

--- a/deploy/hardhat/191_deploy_BTCPoolV2.ts
+++ b/deploy/hardhat/191_deploy_BTCPoolV2.ts
@@ -1,0 +1,73 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, get, getOrNull, log, read, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const SaddleBTCPoolV2 = await getOrNull("SaddleBTCPoolV2")
+  if (SaddleBTCPoolV2) {
+    log(`reusing "SaddleBTCPoolV2" at ${SaddleBTCPoolV2.address}`)
+  } else {
+    // Constructor arguments
+    const TOKEN_ADDRESSES = [
+      (await get("WBTC")).address,
+      (await get("RENBTC")).address,
+      (await get("SBTC")).address,
+    ]
+    const TOKEN_DECIMALS = [8, 8, 18]
+    const LP_TOKEN_NAME = "Saddle WBTC/renBTC/sBTC"
+    const LP_TOKEN_SYMBOL = "saddleWRenSBTC"
+    const INITIAL_A = 200
+    const SWAP_FEE = 4e6 // 4bps
+    const ADMIN_FEE = 0
+
+    const receipt = await execute(
+      "SwapDeployer",
+      { from: deployer, log: true },
+      "deploy",
+      (
+        await get("SwapFlashLoan")
+      ).address,
+      TOKEN_ADDRESSES,
+      TOKEN_DECIMALS,
+      LP_TOKEN_NAME,
+      LP_TOKEN_SYMBOL,
+      INITIAL_A,
+      SWAP_FEE,
+      ADMIN_FEE,
+      (
+        await get("LPToken")
+      ).address,
+    )
+
+    const newPoolEvent = receipt?.events?.find(
+      (e: any) => e["event"] == "NewSwapPool",
+    )
+    const btcSwapAddress = newPoolEvent["args"]["swapAddress"]
+    log(`deployed BTC pool V2 (targeting "SwapFlashLoan") at ${btcSwapAddress}`)
+    await save("SaddleBTCPoolV2", {
+      abi: (await get("SwapFlashLoan")).abi,
+      address: btcSwapAddress,
+    })
+
+    const lpTokenAddress = (await read("SaddleBTCPoolV2", "swapStorage"))
+      .lpToken
+    log(`BTC pool V2 LP Token at ${lpTokenAddress}`)
+
+    await save("SaddleBTCPoolV2LPToken", {
+      abi: (await get("WBTC")).abi, // Generic ERC20 ABI
+      address: lpTokenAddress,
+    })
+  }
+}
+export default func
+func.tags = ["BTCPoolV2"]
+func.dependencies = [
+  "SwapUtils",
+  "SwapDeployer",
+  "SwapFlashLoan",
+  "BTCPoolV2Tokens",
+]

--- a/deploy/hardhat/200_check_TBTCMetaPoolTokens.ts
+++ b/deploy/hardhat/200_check_TBTCMetaPoolTokens.ts
@@ -1,0 +1,38 @@
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { isTestNetwork } from "../../utils/network"
+import { BigNumber } from "ethers"
+
+const USD_TOKENS_ARGS: { [token: string]: any[] } = {
+  TBTCv2: ["tBTC v2", "tbtc", "18"],
+}
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, execute } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  for (const token in USD_TOKENS_ARGS) {
+    await deploy(token, {
+      from: deployer,
+      log: true,
+      contract: "GenericERC20",
+      args: USD_TOKENS_ARGS[token],
+      skipIfAlreadyDeployed: true,
+    })
+    // If it's on hardhat, mint test tokens
+    if (isTestNetwork(await getChainId())) {
+      const decimals = USD_TOKENS_ARGS[token][2]
+      await execute(
+        token,
+        { from: deployer, log: true },
+        "mint",
+        deployer,
+        BigNumber.from(10).pow(decimals).mul(1000000),
+      )
+    }
+  }
+}
+export default func
+func.tags = ["TBTCMetaPoolTokens"]
+func.dependencies = ["BTCPoolV2"]

--- a/deploy/hardhat/201_deploy_TBTCMetaPool.ts
+++ b/deploy/hardhat/201_deploy_TBTCMetaPool.ts
@@ -1,0 +1,78 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, deploy, get, getOrNull, log, read, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const saddleTBTCMetaPool = await getOrNull("SaddleTBTCMetaPool")
+  if (saddleTBTCMetaPool) {
+    log(`reusing "SaddleTBTCMetaPool" at ${saddleTBTCMetaPool.address}`)
+  } else {
+    // Constructor arguments
+    const TOKEN_ADDRESSES = [
+      (await get("TBTCv2")).address,
+      (await get("SaddleBTCPoolV2LPToken")).address,
+    ]
+    const TOKEN_DECIMALS = [18, 18]
+    const LP_TOKEN_NAME = "Saddle tBTCv2/saddleWRenSBTC"
+    const LP_TOKEN_SYMBOL = "saddletBTC"
+    const INITIAL_A = 100
+    const SWAP_FEE = 4e6 // 4bps
+    const ADMIN_FEE = 0
+
+    const receipt = await execute(
+      "SwapDeployer",
+      {
+        from: deployer,
+        log: true,
+      },
+      "deployMetaSwap",
+      (
+        await get("SaddleSUSDMetaPool")
+      ).address,
+      TOKEN_ADDRESSES,
+      TOKEN_DECIMALS,
+      LP_TOKEN_NAME,
+      LP_TOKEN_SYMBOL,
+      INITIAL_A,
+      SWAP_FEE,
+      ADMIN_FEE,
+      (
+        await get("LPToken")
+      ).address,
+      (
+        await get("SaddleBTCPoolV2")
+      ).address,
+    )
+
+    const newPoolEvent = receipt?.events?.find(
+      (e: any) => e["event"] == "NewSwapPool",
+    )
+    const btcSwapAddress = newPoolEvent["args"]["swapAddress"]
+    log(`deployed TBTC meta pool (targeting "MetaSwap") at ${btcSwapAddress}`)
+    await save("SaddleTBTCMetaPool", {
+      abi: (await get("SaddleSUSDMetaPool")).abi,
+      address: btcSwapAddress,
+    })
+
+    const lpTokenAddress = (await read("SaddleTBTCMetaPool", "swapStorage"))
+      .lpToken
+    log(`Saddle tBTC v2 MetaSwap LP Token at ${lpTokenAddress}`)
+
+    await save("SaddleTBTCMetaPoolLPToken", {
+      abi: (await get("LPToken")).abi, // LPToken ABI
+      address: lpTokenAddress,
+    })
+  }
+}
+export default func
+func.tags = ["TBTCMetaPool"]
+func.dependencies = [
+  "LPToken",
+  "USDMetaPool",
+  "TBTCMetaPoolTokens",
+  "BTCPoolV2",
+]

--- a/deploy/hardhat/202_deploy_TBTCMetaPoolDeposit.ts
+++ b/deploy/hardhat/202_deploy_TBTCMetaPoolDeposit.ts
@@ -1,0 +1,60 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, ethers } = hre
+  const { execute, deploy, get, getOrNull, log, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const saddleTBTCMetaPoolDeposit = await getOrNull("SaddleTBTCMetaPoolDeposit")
+  if (saddleTBTCMetaPoolDeposit) {
+    log(
+      `reusing "SaddleTBTCMetaPoolDeposit" at ${saddleTBTCMetaPoolDeposit.address}`,
+    )
+  } else {
+    const susdMetaPoolDeposit = await ethers.getContract(
+      "SaddleSUSDMetaPoolDeposit",
+    )
+
+    const receipt = await execute(
+      "SwapDeployer",
+      {
+        from: deployer,
+        log: true,
+      },
+      "clone",
+      susdMetaPoolDeposit.address,
+    )
+
+    const newPoolEvent = receipt?.events?.find(
+      (e: any) => e["event"] == "NewClone",
+    )
+    const btcSwapAddress = newPoolEvent["args"]["cloneAddress"]
+    log(
+      `deployed TBTC meta pool deposit (targeting "MetaPoolDeposit") at ${btcSwapAddress}`,
+    )
+    await save("SaddleTBTCMetaPoolDeposit", {
+      abi: (await get("SaddleSUSDMetaPoolDeposit")).abi,
+      address: btcSwapAddress,
+    })
+
+    await execute(
+      "SaddleTBTCMetaPoolDeposit",
+      { from: deployer, log: true },
+      "initialize",
+      (
+        await get("SaddleBTCPoolV2")
+      ).address,
+      (
+        await get("SaddleTBTCMetaPool")
+      ).address,
+      (
+        await get("SaddleTBTCMetaPoolLPToken")
+      ).address,
+    )
+  }
+}
+export default func
+func.tags = ["TBTCMetaPoolDeposit"]
+func.dependencies = ["TBTCMetaPoolTokens", "TBTCMetaPool"]

--- a/deploy/hardhat/210_check_CUSDMetaPoolTokens.ts
+++ b/deploy/hardhat/210_check_CUSDMetaPoolTokens.ts
@@ -1,0 +1,38 @@
+import { BigNumber } from "ethers"
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { isTestNetwork } from "../../utils/network"
+
+const USD_TOKENS_ARGS: { [token: string]: any[] } = {
+  WCUSD: ["Wrapped Celo USD", "wCUSD", "18"],
+}
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, execute } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  for (const token in USD_TOKENS_ARGS) {
+    await deploy(token, {
+      from: deployer,
+      log: true,
+      contract: "GenericERC20",
+      args: USD_TOKENS_ARGS[token],
+      skipIfAlreadyDeployed: true,
+    })
+    // If it's on hardhat, mint test tokens
+    if (isTestNetwork(await getChainId())) {
+      const decimals = USD_TOKENS_ARGS[token][2]
+      await execute(
+        token,
+        { from: deployer, log: true },
+        "mint",
+        deployer,
+        BigNumber.from(10).pow(decimals).mul(1000000),
+      )
+    }
+  }
+}
+export default func
+func.tags = ["WCUSDMetaPoolTokens"]
+func.dependencies = ["USDPoolV2"]

--- a/deploy/hardhat/211_deploy_CUSDMetaPool.ts
+++ b/deploy/hardhat/211_deploy_CUSDMetaPool.ts
@@ -1,0 +1,85 @@
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { MULTISIG_ADDRESSES } from "../../utils/accounts"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { execute, deploy, get, getOrNull, log, read, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const saddleWCUSDMetaPool = await getOrNull("SaddleWCUSDMetaPool")
+  if (saddleWCUSDMetaPool) {
+    log(`reusing "SaddleWCUSDMetaPool" at ${saddleWCUSDMetaPool.address}`)
+  } else {
+    // Constructor arguments
+    const TOKEN_ADDRESSES = [
+      (await get("WCUSD")).address,
+      (await get("SaddleUSDPoolV2LPToken")).address,
+    ]
+    const TOKEN_DECIMALS = [18, 18]
+    const LP_TOKEN_NAME = "Saddle wCUSD/saddleUSD-V2"
+    const LP_TOKEN_SYMBOL = "saddleWCUSD"
+    const INITIAL_A = 100
+    const SWAP_FEE = 4e6 // 4bps
+    const ADMIN_FEE = 0
+
+    await deploy("SaddleWCUSDMetaPool", {
+      from: deployer,
+      log: true,
+      contract: "MetaSwap",
+      skipIfAlreadyDeployed: true,
+      libraries: {
+        SwapUtils: (await get("SwapUtils")).address,
+        MetaSwapUtils: (await get("MetaSwapUtils")).address,
+        AmplificationUtils: (await get("AmplificationUtils")).address,
+      },
+    })
+
+    await execute(
+      "SaddleWCUSDMetaPool",
+      {
+        from: deployer,
+        log: true,
+      },
+      "initializeMetaSwap",
+      TOKEN_ADDRESSES,
+      TOKEN_DECIMALS,
+      LP_TOKEN_NAME,
+      LP_TOKEN_SYMBOL,
+      INITIAL_A,
+      SWAP_FEE,
+      ADMIN_FEE,
+      (
+        await get("LPToken")
+      ).address,
+      (
+        await get("SaddleUSDPoolV2")
+      ).address,
+    )
+
+    await execute(
+      "SaddleWCUSDMetaPool",
+      { from: deployer, log: true },
+      "transferOwnership",
+      MULTISIG_ADDRESSES[await getChainId()],
+    )
+
+    const lpTokenAddress = (await read("SaddleWCUSDMetaPool", "swapStorage"))
+      .lpToken
+    log(`Saddle wCUSD MetaSwap LP Token at ${lpTokenAddress}`)
+
+    await save("SaddleWCUSDMetaPoolLPToken", {
+      abi: (await get("LPToken")).abi, // LPToken ABI
+      address: lpTokenAddress,
+    })
+  }
+}
+export default func
+func.tags = ["WCUSDMetaPool"]
+func.dependencies = [
+  "WCUSDMetaPoolTokens",
+  "USDPoolV2",
+  "MetaSwapUtils",
+  "AmplificationUtils",
+]

--- a/deploy/hardhat/212_deploy_CUSDMetaPoolDeposit.ts
+++ b/deploy/hardhat/212_deploy_CUSDMetaPoolDeposit.ts
@@ -1,0 +1,41 @@
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, deploy, get, getOrNull, log } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const saddleWCUSDMetaPool = await getOrNull("SaddleWCUSDMetaPoolDeposit")
+  if (saddleWCUSDMetaPool) {
+    log(
+      `reusing "SaddleWCUSDMetaPoolDeposit" at ${saddleWCUSDMetaPool.address}`,
+    )
+  } else {
+    await deploy("SaddleWCUSDMetaPoolDeposit", {
+      from: deployer,
+      log: true,
+      contract: "MetaSwapDeposit",
+      skipIfAlreadyDeployed: true,
+    })
+
+    await execute(
+      "SaddleWCUSDMetaPoolDeposit",
+      { from: deployer, log: true },
+      "initialize",
+      (
+        await get("SaddleUSDPoolV2")
+      ).address,
+      (
+        await get("SaddleWCUSDMetaPool")
+      ).address,
+      (
+        await get("SaddleWCUSDMetaPoolLPToken")
+      ).address,
+    )
+  }
+}
+export default func
+func.tags = ["WCUSDMetaPoolDeposit"]
+func.dependencies = ["WCUSDMetaPoolTokens", "WCUSDMetaPool"]

--- a/deploy/hardhat/220_deploy_SynthSwapper.ts
+++ b/deploy/hardhat/220_deploy_SynthSwapper.ts
@@ -1,0 +1,18 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  await deploy("SynthSwapper", {
+    from: deployer,
+    log: true,
+    contract: "SynthSwapper",
+    skipIfAlreadyDeployed: true,
+  })
+}
+export default func
+func.tags = ["SynthSwapper"]

--- a/deploy/hardhat/230_deploy_Bridge.ts
+++ b/deploy/hardhat/230_deploy_Bridge.ts
@@ -1,0 +1,26 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { CHAIN_ID } from "../../utils/network"
+import path from "path"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { get, log, deploy } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  if ((await getChainId()) == CHAIN_ID.MAINNET) {
+    // Manually check if the pool is already deployed
+    await deploy("Bridge", {
+      from: deployer,
+      log: true,
+      contract: "Bridge",
+      args: [(await get("SynthSwapper")).address],
+      skipIfAlreadyDeployed: true,
+    })
+  } else {
+    log(`deployment is not on mainnet. skipping ${path.basename(__filename)}`)
+  }
+}
+export default func
+func.tags = ["Bridge"]
+func.dependencies = ["SynthSwapper"]

--- a/deploy/hardhat/231_initialize_Bridge.ts
+++ b/deploy/hardhat/231_initialize_Bridge.ts
@@ -1,0 +1,52 @@
+import { CHAIN_ID } from "../../utils/network"
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { asyncForEach } from "../../test/testUtils"
+import path from "path"
+import { utils } from "ethers"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { execute, get, read, log } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const poolConfigs = [
+    {
+      swapAddress: (await get("SaddleBTCPool")).address,
+      synthIndex: 3,
+      currencyKey: utils.formatBytes32String("sBTC"),
+    },
+    {
+      swapAddress: (await get("SaddleALETHPool")).address,
+      synthIndex: 2,
+      currencyKey: utils.formatBytes32String("sETH"),
+    },
+    {
+      swapAddress: (await get("SaddleSUSDMetaPoolDeposit")).address,
+      synthIndex: 0,
+      currencyKey: utils.formatBytes32String("sUSD"),
+    },
+  ]
+
+  if ((await getChainId()) == CHAIN_ID.MAINNET) {
+    await asyncForEach(poolConfigs, async (config) => {
+      try {
+        await read("Bridge", "getSynthIndex", config.swapAddress)
+      } catch {
+        await execute(
+          "Bridge",
+          { from: deployer, log: true },
+          "setSynthIndex",
+          config.swapAddress,
+          config.synthIndex,
+          config.currencyKey,
+        )
+      }
+    })
+  } else {
+    log(`deployment is not on mainnet. skipping ${path.basename(__filename)}`)
+  }
+}
+export default func
+func.tags = ["Bridge"]
+func.dependencies = ["SynthSwapper"]

--- a/deploy/hardhat/240_deploy_SUSDMetaPoolUpdated.ts
+++ b/deploy/hardhat/240_deploy_SUSDMetaPoolUpdated.ts
@@ -1,0 +1,88 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { MULTISIG_ADDRESSES } from "../../utils/accounts"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { execute, deploy, get, getOrNull, log, read, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const saddleSUSDMetaPool = await getOrNull("SaddleSUSDMetaPoolUpdated")
+  if (saddleSUSDMetaPool) {
+    log(`reusing "SaddleSUSDMetaPool" at ${saddleSUSDMetaPool.address}`)
+  } else {
+    // Constructor arguments
+    const TOKEN_ADDRESSES = [
+      (await get("SUSD")).address,
+      (await get("SaddleUSDPoolV2LPToken")).address,
+    ]
+    const TOKEN_DECIMALS = [18, 18]
+    const LP_TOKEN_NAME = "Saddle sUSD/saddleUSD-V2"
+    const LP_TOKEN_SYMBOL = "saddleSUSD"
+    const INITIAL_A = 100
+    const SWAP_FEE = 4e6 // 4bps
+    const ADMIN_FEE = 0
+
+    await deploy("SaddleSUSDMetaPoolUpdated", {
+      from: deployer,
+      log: true,
+      contract: "MetaSwap",
+      skipIfAlreadyDeployed: true,
+      libraries: {
+        SwapUtils: (await get("SwapUtils")).address,
+        MetaSwapUtils: (await get("MetaSwapUtils")).address,
+        AmplificationUtils: (await get("AmplificationUtils")).address,
+      },
+    })
+
+    await save("MetaSwapUpdated", await get("SaddleSUSDMetaPoolUpdated"))
+
+    await execute(
+      "SaddleSUSDMetaPoolUpdated",
+      {
+        from: deployer,
+        log: true,
+      },
+      "initializeMetaSwap",
+      TOKEN_ADDRESSES,
+      TOKEN_DECIMALS,
+      LP_TOKEN_NAME,
+      LP_TOKEN_SYMBOL,
+      INITIAL_A,
+      SWAP_FEE,
+      ADMIN_FEE,
+      (
+        await get("LPToken")
+      ).address,
+      (
+        await get("SaddleUSDPoolV2")
+      ).address,
+    )
+
+    await execute(
+      "SaddleSUSDMetaPoolUpdated",
+      { from: deployer, log: true },
+      "transferOwnership",
+      MULTISIG_ADDRESSES[await getChainId()],
+    )
+
+    const lpTokenAddress = (
+      await read("SaddleSUSDMetaPoolUpdated", "swapStorage")
+    ).lpToken
+    log(`Saddle sUSD MetaSwap LP Token at ${lpTokenAddress}`)
+
+    await save("SaddleSUSDMetaPoolUpdatedLPToken", {
+      abi: (await get("LPToken")).abi, // LPToken ABI
+      address: lpTokenAddress,
+    })
+  }
+}
+export default func
+func.tags = ["SaddleSUSDMetaPoolUpdated"]
+func.dependencies = [
+  "SUSDMetaPoolTokens",
+  "USDPoolV2",
+  "MetaSwapUtils",
+  "AmplificationUtils",
+]

--- a/deploy/hardhat/241_deploy_SUSDMetaPoolUpdatedDeposit.ts
+++ b/deploy/hardhat/241_deploy_SUSDMetaPoolUpdatedDeposit.ts
@@ -1,0 +1,58 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, deploy, get, getOrNull, log, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const saddleSUSDMetaPool = await getOrNull("SaddleSUSDMetaPoolUpdatedDeposit")
+  if (saddleSUSDMetaPool) {
+    log(
+      `reusing "SaddleSUSDMetaPoolUpdatedDeposit" at ${saddleSUSDMetaPool.address}`,
+    )
+  } else {
+    const receipt = await execute(
+      "SwapDeployer",
+      {
+        from: deployer,
+        log: true,
+      },
+      "clone",
+      (
+        await get("SaddleSUSDMetaPoolDeposit")
+      ).address,
+    )
+
+    const newPoolEvent = receipt?.events?.find(
+      (e: any) => e["event"] == "NewClone",
+    )
+    const metaSwapDepositAddress = newPoolEvent["args"]["cloneAddress"]
+    log(
+      `deployed SUSD meta pool deposit (targeting "MetaPoolDeposit") at ${metaSwapDepositAddress}`,
+    )
+    await save("SaddleSUSDMetaPoolUpdatedDeposit", {
+      abi: (await get("SaddleSUSDMetaPoolDeposit")).abi,
+      address: metaSwapDepositAddress,
+    })
+
+    await execute(
+      "SaddleSUSDMetaPoolUpdatedDeposit",
+      { from: deployer, log: true, gasLimit: 1_000_000 },
+      "initialize",
+      (
+        await get("SaddleUSDPoolV2")
+      ).address,
+      (
+        await get("SaddleSUSDMetaPoolUpdated")
+      ).address,
+      (
+        await get("SaddleSUSDMetaPoolUpdatedLPToken")
+      ).address,
+    )
+  }
+}
+export default func
+func.tags = ["SUSDMetaPoolUpdatedDeposit"]
+func.dependencies = ["SUSDMetaPoolTokens", "SUSDMetaPoolUpdated"]

--- a/deploy/hardhat/250_deploy_TBTCMetaPoolUpdated.ts
+++ b/deploy/hardhat/250_deploy_TBTCMetaPoolUpdated.ts
@@ -1,0 +1,79 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, deploy, get, getOrNull, log, read, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const saddleTBTCMetaPool = await getOrNull("SaddleTBTCMetaPoolUpdated")
+  if (saddleTBTCMetaPool) {
+    log(`reusing "SaddleTBTCMetaPoolUpdated" at ${saddleTBTCMetaPool.address}`)
+  } else {
+    // Constructor arguments
+    const TOKEN_ADDRESSES = [
+      (await get("TBTCv2")).address,
+      (await get("SaddleBTCPoolV2LPToken")).address,
+    ]
+    const TOKEN_DECIMALS = [18, 18]
+    const LP_TOKEN_NAME = "Saddle tBTCv2/saddleWRenSBTC"
+    const LP_TOKEN_SYMBOL = "saddletBTC"
+    const INITIAL_A = 100
+    const SWAP_FEE = 4e6 // 4bps
+    const ADMIN_FEE = 0
+
+    const receipt = await execute(
+      "SwapDeployer",
+      {
+        from: deployer,
+        log: true,
+      },
+      "deployMetaSwap",
+      (
+        await get("SaddleSUSDMetaPoolUpdated")
+      ).address,
+      TOKEN_ADDRESSES,
+      TOKEN_DECIMALS,
+      LP_TOKEN_NAME,
+      LP_TOKEN_SYMBOL,
+      INITIAL_A,
+      SWAP_FEE,
+      ADMIN_FEE,
+      (
+        await get("LPToken")
+      ).address,
+      (
+        await get("SaddleBTCPoolV2")
+      ).address,
+    )
+
+    const newPoolEvent = receipt?.events?.find(
+      (e: any) => e["event"] == "NewSwapPool",
+    )
+    const btcSwapAddress = newPoolEvent["args"]["swapAddress"]
+    log(`deployed TBTC meta pool (targeting "MetaSwap") at ${btcSwapAddress}`)
+    await save("SaddleTBTCMetaPoolUpdated", {
+      abi: (await get("SaddleSUSDMetaPoolUpdated")).abi,
+      address: btcSwapAddress,
+    })
+
+    const lpTokenAddress = (
+      await read("SaddleTBTCMetaPoolUpdated", "swapStorage")
+    ).lpToken
+    log(`Saddle tBTC v2 MetaSwap LP Token at ${lpTokenAddress}`)
+
+    await save("SaddleTBTCMetaPoolUpdatedLPToken", {
+      abi: (await get("LPToken")).abi, // LPToken ABI
+      address: lpTokenAddress,
+    })
+  }
+}
+export default func
+func.tags = ["TBTCMetaPoolUpdated"]
+func.dependencies = [
+  "LPToken",
+  "USDMetaPool",
+  "TBTCMetaPoolTokens",
+  "BTCPoolV2",
+]

--- a/deploy/hardhat/251_deploy_TBTCMetaPoolUpdatedDeposit.ts
+++ b/deploy/hardhat/251_deploy_TBTCMetaPoolUpdatedDeposit.ts
@@ -1,0 +1,60 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, ethers } = hre
+  const { execute, deploy, get, getOrNull, log, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const saddleTBTCMetaPoolDeposit = await getOrNull(
+    "SaddleTBTCMetaPoolUpdatedDeposit",
+  )
+  if (saddleTBTCMetaPoolDeposit) {
+    log(
+      `reusing "SaddleTBTCMetaPoolUpdatedDeposit" at ${saddleTBTCMetaPoolDeposit.address}`,
+    )
+  } else {
+    const receipt = await execute(
+      "SwapDeployer",
+      {
+        from: deployer,
+        log: true,
+      },
+      "clone",
+      (
+        await get("SaddleSUSDMetaPoolDeposit")
+      ).address,
+    )
+
+    const newPoolEvent = receipt?.events?.find(
+      (e: any) => e["event"] == "NewClone",
+    )
+    const metaSwapDeposit = newPoolEvent["args"]["cloneAddress"]
+    log(
+      `deployed TBTC meta pool deposit (targeting "MetaPoolDeposit") at ${metaSwapDeposit}`,
+    )
+    await save("SaddleTBTCMetaPoolUpdatedDeposit", {
+      abi: (await get("SaddleSUSDMetaPoolDeposit")).abi,
+      address: metaSwapDeposit,
+    })
+
+    await execute(
+      "SaddleTBTCMetaPoolUpdatedDeposit",
+      { from: deployer, log: true, gasLimit: 1_000_000 },
+      "initialize",
+      (
+        await get("SaddleBTCPoolV2")
+      ).address,
+      (
+        await get("SaddleTBTCMetaPoolUpdated")
+      ).address,
+      (
+        await get("SaddleTBTCMetaPoolUpdatedLPToken")
+      ).address,
+    )
+  }
+}
+export default func
+func.tags = ["TBTCMetaPoolUpdatedDeposit"]
+func.dependencies = ["TBTCMetaPoolTokens", "TBTCMetaPoolUpdated"]

--- a/deploy/hardhat/260_deploy_CUSDMetaPoolUpdated.ts
+++ b/deploy/hardhat/260_deploy_CUSDMetaPoolUpdated.ts
@@ -1,0 +1,81 @@
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, deploy, get, getOrNull, log, read, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const saddleWCUSDMetaPool = await getOrNull("SaddleWCUSDMetaPoolUpdated")
+  if (saddleWCUSDMetaPool) {
+    log(
+      `reusing "SaddleWCUSDMetaPoolUpdated" at ${saddleWCUSDMetaPool.address}`,
+    )
+  } else {
+    // Constructor arguments
+    const TOKEN_ADDRESSES = [
+      (await get("WCUSD")).address,
+      (await get("SaddleUSDPoolV2LPToken")).address,
+    ]
+    const TOKEN_DECIMALS = [18, 18]
+    const LP_TOKEN_NAME = "Saddle wCUSD/saddleUSD-V2"
+    const LP_TOKEN_SYMBOL = "saddleWCUSD"
+    const INITIAL_A = 100
+    const SWAP_FEE = 4e6 // 4bps
+    const ADMIN_FEE = 0
+
+    const receipt = await execute(
+      "SwapDeployer",
+      {
+        from: deployer,
+        log: true,
+      },
+      "deployMetaSwap",
+      (
+        await get("SaddleSUSDMetaPoolUpdated")
+      ).address,
+      TOKEN_ADDRESSES,
+      TOKEN_DECIMALS,
+      LP_TOKEN_NAME,
+      LP_TOKEN_SYMBOL,
+      INITIAL_A,
+      SWAP_FEE,
+      ADMIN_FEE,
+      (
+        await get("LPToken")
+      ).address,
+      (
+        await get("SaddleUSDPoolV2")
+      ).address,
+    )
+
+    const newPoolEvent = receipt?.events?.find(
+      (e: any) => e["event"] == "NewSwapPool",
+    )
+    const metaSwapAddress = newPoolEvent["args"]["swapAddress"]
+    log(`deployed CUSD meta pool (targeting "MetaSwap") at ${metaSwapAddress}`)
+    await save("SaddleWCUSDMetaPoolUpdated", {
+      abi: (await get("SaddleSUSDMetaPoolUpdated")).abi,
+      address: metaSwapAddress,
+    })
+
+    const lpTokenAddress = (
+      await read("SaddleWCUSDMetaPoolUpdated", "swapStorage")
+    ).lpToken
+    log(`Saddle wCUSD MetaSwap LP Token at ${lpTokenAddress}`)
+
+    await save("SaddleWCUSDMetaPoolUpdatedLPToken", {
+      abi: (await get("LPToken")).abi, // LPToken ABI
+      address: lpTokenAddress,
+    })
+  }
+}
+export default func
+func.tags = ["WCUSDMetaPoolUpdated"]
+func.dependencies = [
+  "WCUSDMetaPoolTokens",
+  "USDPoolV2",
+  "MetaSwapUtils",
+  "AmplificationUtils",
+]

--- a/deploy/hardhat/261_deploy_CUSDMetaPoolUpdatedDeposit.ts
+++ b/deploy/hardhat/261_deploy_CUSDMetaPoolUpdatedDeposit.ts
@@ -1,0 +1,60 @@
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, deploy, get, getOrNull, log, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const saddleWCUSDMetaPool = await getOrNull(
+    "SaddleWCUSDMetaPoolUpdatedDeposit",
+  )
+  if (saddleWCUSDMetaPool) {
+    log(
+      `reusing "SaddleWCUSDMetaPoolUpdatedDeposit" at ${saddleWCUSDMetaPool.address}`,
+    )
+  } else {
+    const receipt = await execute(
+      "SwapDeployer",
+      {
+        from: deployer,
+        log: true,
+      },
+      "clone",
+      (
+        await get("SaddleSUSDMetaPoolDeposit")
+      ).address,
+    )
+
+    const newPoolEvent = receipt?.events?.find(
+      (e: any) => e["event"] == "NewClone",
+    )
+    const metaSwapDeposit = newPoolEvent["args"]["cloneAddress"]
+    log(
+      `deployed WCUSD meta pool deposit (targeting "MetaPoolDeposit") at ${metaSwapDeposit}`,
+    )
+    await save("SaddleWCUSDMetaPoolUpdatedDeposit", {
+      abi: (await get("SaddleSUSDMetaPoolDeposit")).abi,
+      address: metaSwapDeposit,
+    })
+
+    await execute(
+      "SaddleWCUSDMetaPoolUpdatedDeposit",
+      { from: deployer, log: true, gasLimit: 1_000_000 },
+      "initialize",
+      (
+        await get("SaddleUSDPoolV2")
+      ).address,
+      (
+        await get("SaddleWCUSDMetaPoolUpdated")
+      ).address,
+      (
+        await get("SaddleWCUSDMetaPoolUpdatedLPToken")
+      ).address,
+    )
+  }
+}
+export default func
+func.tags = ["WCUSDMetaPoolUpdatedDeposit"]
+func.dependencies = ["WCUSDMetaPoolTokens", "WCUSDMetaPoolUpdated"]

--- a/deploy/hardhat/270_deploy_GeneralizedSwapMigrator.ts
+++ b/deploy/hardhat/270_deploy_GeneralizedSwapMigrator.ts
@@ -1,0 +1,128 @@
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { ethers } from "hardhat"
+import { GeneralizedSwapMigrator } from "../../build/typechain"
+import { MULTISIG_ADDRESSES } from "../../utils/accounts"
+import { CHAIN_ID } from "../../utils/network"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { execute, deploy, get, getOrNull, log, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const genSwapMigrator = await getOrNull("GeneralizedSwapMigrator")
+  if (genSwapMigrator) {
+    log(`reusing "GeneralizedSwapMigrator" at ${genSwapMigrator.address}`)
+  } else {
+    await deploy("GeneralizedSwapMigrator", {
+      from: deployer,
+      log: true,
+    })
+
+    const contract: GeneralizedSwapMigrator = await ethers.getContract(
+      "GeneralizedSwapMigrator",
+    )
+    const batchCall = [
+      await contract.populateTransaction.addMigrationData(
+        (
+          await get("SaddleUSDPool")
+        ).address,
+        {
+          newPoolAddress: (await get("SaddleUSDPoolV2")).address,
+          oldPoolLPTokenAddress: (await get("SaddleUSDPoolLPToken")).address,
+          newPoolLPTokenAddress: (await get("SaddleUSDPoolV2LPToken")).address,
+          tokens: [
+            (await get("DAI")).address,
+            (await get("USDC")).address,
+            (await get("USDT")).address,
+          ],
+        },
+        false,
+      ),
+      await contract.populateTransaction.addMigrationData(
+        (
+          await get("SaddleSUSDMetaPool")
+        ).address,
+        {
+          newPoolAddress: (await get("SaddleSUSDMetaPoolUpdated")).address,
+          oldPoolLPTokenAddress: (
+            await get("SaddleSUSDMetaPoolLPToken")
+          ).address,
+          newPoolLPTokenAddress: (
+            await get("SaddleSUSDMetaPoolUpdatedLPToken")
+          ).address,
+          tokens: [
+            (await get("SUSD")).address,
+            (await get("SaddleUSDPoolV2LPToken")).address,
+          ],
+        },
+        false,
+      ),
+      await contract.populateTransaction.addMigrationData(
+        (
+          await get("SaddleTBTCMetaPool")
+        ).address,
+        {
+          newPoolAddress: (await get("SaddleTBTCMetaPoolUpdated")).address,
+          oldPoolLPTokenAddress: (
+            await get("SaddleTBTCMetaPoolLPToken")
+          ).address,
+          newPoolLPTokenAddress: (
+            await get("SaddleTBTCMetaPoolUpdatedLPToken")
+          ).address,
+          tokens: [
+            (await get("TBTCv2")).address,
+            (await get("SaddleBTCPoolV2LPToken")).address,
+          ],
+        },
+        false,
+      ),
+      await contract.populateTransaction.addMigrationData(
+        (
+          await get("SaddleWCUSDMetaPool")
+        ).address,
+        {
+          newPoolAddress: (await get("SaddleWCUSDMetaPoolUpdated")).address,
+          oldPoolLPTokenAddress: (
+            await get("SaddleWCUSDMetaPoolLPToken")
+          ).address,
+          newPoolLPTokenAddress: (
+            await get("SaddleWCUSDMetaPoolUpdatedLPToken")
+          ).address,
+          tokens: [
+            (await get("WCUSD")).address,
+            (await get("SaddleUSDPoolV2LPToken")).address,
+          ],
+        },
+        false,
+      ),
+    ]
+
+    if ((await getChainId()) == CHAIN_ID.MAINNET) {
+      batchCall.push(
+        await contract.populateTransaction.transferOwnership(
+          MULTISIG_ADDRESSES[await getChainId()],
+        ),
+      )
+    }
+
+    const batchCallData = batchCall
+      .map((x) => x.data)
+      .filter((x): x is string => !!x)
+
+    await execute(
+      "GeneralizedSwapMigrator",
+      {
+        from: deployer,
+        log: true,
+      },
+      "batch",
+      batchCallData,
+      true,
+    )
+  }
+}
+export default func
+func.tags = ["GeneralizedSwapMigrator"]
+func.dependencies = ["WCUSDMetaPoolTokens", "WCUSDMetaPoolUpdated"]

--- a/deploy/hardhat/300_deploy_Vesting.ts
+++ b/deploy/hardhat/300_deploy_Vesting.ts
@@ -1,0 +1,16 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  await deploy("Vesting", {
+    from: deployer,
+    log: true,
+    skipIfAlreadyDeployed: true,
+  })
+}
+export default func
+func.tags = ["Vesting"]

--- a/deploy/hardhat/301_deploy_SDL.ts
+++ b/deploy/hardhat/301_deploy_SDL.ts
@@ -1,0 +1,21 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, get, execute, getOrNull } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  await deploy("SDL", {
+    from: deployer,
+    log: true,
+    skipIfAlreadyDeployed: true,
+    args: [
+      deployer,
+      7890000, // 3 months in seconds
+      (await get("Vesting")).address,
+    ],
+  })
+}
+export default func
+func.tags = ["SDL"]

--- a/deploy/hardhat/302_deploy_Vesting_clones.ts
+++ b/deploy/hardhat/302_deploy_Vesting_clones.ts
@@ -1,0 +1,380 @@
+import {
+  BIG_NUMBER_1E18,
+  MAX_UINT256,
+  getCurrentBlockTimestamp,
+} from "../../test/testUtils"
+import { BigNumber } from "ethers"
+
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+
+const getFirstRoundAllocation = function (amount: number): BigNumber {
+  return BIG_NUMBER_1E18.mul(90_000_000).mul(amount).div(1170000)
+}
+
+const getSecondRoundAllocation = function (amount: number): BigNumber {
+  return BIG_NUMBER_1E18.mul(105_000_000).mul(amount).div(3150000)
+}
+
+const getThirdRoundAllocation = function (amount: number): BigNumber {
+  return BIG_NUMBER_1E18.mul(30_000_000).mul(amount).div(7500000)
+}
+
+const FIRST_ROUND_INVESTORS: { [address: string]: number } = {
+  "0x3b08AA814bEA604917418A9F0907E7fC430e742C": 400000,
+  "0x987FC4FC9aba7fFbDb3E8d0F9FfED364E01DC18c": 170000,
+  "0xdB7A80DdfDeB83573636B84862803bB07317194C": 150000,
+  "0xCf67910ed04fB23a2ccff3A4bEC259Bb0bf3841c": 50000,
+  "0x23F322Fe50BD1eb7488bAbA33dA56A95Bd2f5815": 50000,
+  "0x6C2a066B6CE2872BD5398347E97223C6F6F84104": 30000,
+  "0x83b1a48376E045D26420200345414e6b93066396": 30000,
+  "0x4F20Cb7a1D567A54350a18DAcB0cc803aEBB4483": 30000,
+  "0xc90eA4d8D214D548221EE3622a8BE1D61f7077A2": 30000,
+  "0xB3E2B1808ab9e81F3Abfc8C9f78B1dD680Cef948": 20000,
+  "0x50AdF7A75d7cD6132ACc0a2FB21C019011286635": 20000,
+  "0xde3258c1c45a557f4924d1e4e3d0a4e5341607ee": 20000,
+  "0x30A14d1BfBa95f1867a67Ae8C18A950075592C99": 20000,
+  "0x67E3ea119E141406c37e2CA783b749Fe1437673f": 20000,
+  "0x8d7C49bF99861A4A189F8adf7882BD85f47E298D": 20000,
+  "0x9AF628d4Fb349c2bA6B4813bBde613A1668b346c": 20000,
+  "0x5e1042b15B3B0Cf1875A7e9Ea379A9e75318a099": 20000,
+  "0x231A07C825f052B895DE5FD1513CE40D18E14aF5": 20000,
+  "0x973B1E385659E317Dd43B49C29E45e66c0275696": 20000,
+  "0x79129d8A02d60D9E9AcF47632B11fC56DE3EcB08": 20000,
+  // "TODO 5": 10000,
+}
+
+const SECOND_ROUND_INVESTORS: { [address: string]: number } = {
+  "0x74c5E6Dc988989D3025292C94d36B9e0ABBcf3d0": 1000000,
+  "0xda7Dc67829F5c1Ad7eC4C6174a6Fbbc722229a40": 1000000,
+  "0xA44ED7D06cbEE6F7d166A7298Ec61724C08163F5": 750000,
+  "0xe5D0Ef77AED07C302634dC370537126A2CD26590": 100000,
+  "0x43Bf99D656be7c354B26e63F01f18faB88714D64": 50000,
+  "0x6b339824883E59676EA605260E4DdA71DcCA29Ae": 25000,
+  "0x4d108e41b380AeCd04693690996192BEEe29174c": 25000,
+  // "TODO 2": 25000,
+  "0x4e7541783a0256e0EEf6cCA2b175Da79548db269": 25000,
+  // "TODO 3": 25000,
+  "0xe016ec54349e1fdc09c86878f25760ed317a7911": 25000,
+  "0x7fCAf93cc92d51c490FFF701fb2C6197497a80db": 25000,
+  "0xb4d47Add34a5dF5Ce64DdC6e926A99fc1F8F817f": 25000,
+  "0x92DE4fF2037f8508c8A2D8EfB61868B284c6081c": 20000,
+  "0xdd85061c99d4c6F4B199333ccE156CD5C6dc03a3": 20000,
+  "0xf75B575FB27BEF41bb2825E96Dc53D5E95BA26Fe": 10000,
+}
+
+const THIRD_ROUND_INVESTORS: { [address: string]: number } = {
+  "0x89a88bcfe0A8BB0BD240FACf5f20385Cdc48eC4C": 3000000,
+  "0xbf6b82232Ab643ffb85578868B74919fE30E26e2": 2675625,
+  "0x72E5f354645e8212D3Fa9B80717E6c31887eAa7F": 324375,
+  "0xFcfBF39D5211498AfD8a00C07AAD44A2a96118d0": 294138,
+  "0xe2eC0bC10C1ac3510a6687481d2dFa567e340469": 255000,
+  "0x806b885aCb0494925c68C279C2A1D3C03ed67FC6": 165862,
+  "0xdB7A80DdfDeB83573636B84862803bB07317194C": 150000,
+  "0x3631401a11ba7004d1311e24d177b05ece39b4b3": 150000,
+  "0xaC136EdAa6e5280e344dd3a2d463d7C5Ed93cDC5": 83060,
+  "0xcA59254EF758Ddfa5aae350422Fdd816c11D9031": 75000,
+  "0x8D60876891Ed33e0d40Ff677baDb9b8A9E775CC5": 50000,
+  "0xd9d77Edc0650261e0b2b1F99327d538A613BF930": 50000,
+  "0xA58d1ebC8f9526fBdAE0aeb12532D13BA2ddf871": 50000,
+  "0x2550761D44e709710C15B718B2B73A65151a8488": 40000,
+  "0x156c2d0D9CfA744615b022229026423E24a566ee": 25000,
+  "0xbB49444efe86b167d1Cc35C79A9eb39110DbD5E3": 25000,
+  "0xb9136F75e4F0eFAb9869c6C1d4659E3a585E9091": 20000,
+  "0x44692cd1FBd67acFA3cA0c089B4f06dFae07df79": 16940,
+  "0x546560eFB65988D2c94E37b59CA11629C8584f91": 10000,
+  "0x84ADB7653B176A5cEeBCe0b927f83F0D3eFD89c7": 10000,
+  "0x3f1f7df41cce79f4840067106184079236784ad2": 10000,
+  "0x4e33D9523AB9CC36cDf923dEe0E8a7d11308595b": 10000,
+  "0x31421C442c422BD16aef6ae44D3b11F404eeaBd9": 10000,
+}
+
+const MULTISIG_ADDRESS = "0x3F8E527aF4e0c6e763e8f368AC679c44C45626aE"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, get, execute } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  interface Recipient {
+    to: string
+    amount: BigNumber
+    startTimestamp: BigNumber
+    cliffPeriod: BigNumber
+    durationPeriod: BigNumber
+  }
+
+  // Investor vesting schedule
+  const TWO_YEARS_IN_SEC = BigNumber.from(2).mul(365).mul(24).mul(60).mul(60)
+
+  // Team/advisor vesting schedule
+  const THREE_YEARS_IN_SEC = BigNumber.from(3).mul(365).mul(24).mul(60).mul(60)
+
+  // Tuesday, November 16, 2021 12:00:00 AM UTC
+  // This cannot be set in the future!
+  const TOKEN_LAUNCH_TIMESTAMP = BigNumber.from(
+    await getCurrentBlockTimestamp(),
+  )
+
+  // Wednesday, July 7, 2021 12:00:00 AM UTC
+  const FIRST_BATCH_TEAM_VESTING_START_TIMESTAMP = BigNumber.from(1625616000)
+
+  // Monday, October 4, 2021 12:00:00 AM UTC
+  const SECOND_BATCH_TEAM_VESTING_START_TIMESTAMP = BigNumber.from(1633305600)
+
+  const investorGrants: { [address: string]: BigNumber } = {}
+
+  // Combine grants across rounds so that we only deploy a single vesting contract for any given address
+  for (const [address, amount] of Object.entries(FIRST_ROUND_INVESTORS)) {
+    if (investorGrants[address]) {
+      investorGrants[address] = investorGrants[address].add(
+        getFirstRoundAllocation(amount),
+      )
+    } else {
+      investorGrants[address] = getFirstRoundAllocation(amount)
+    }
+  }
+
+  for (const [address, amount] of Object.entries(SECOND_ROUND_INVESTORS)) {
+    if (investorGrants[address]) {
+      investorGrants[address] = investorGrants[address].add(
+        getSecondRoundAllocation(amount),
+      )
+    } else {
+      investorGrants[address] = getSecondRoundAllocation(amount)
+    }
+  }
+
+  for (const [address, amount] of Object.entries(THIRD_ROUND_INVESTORS)) {
+    if (investorGrants[address]) {
+      investorGrants[address] = investorGrants[address].add(
+        getThirdRoundAllocation(amount),
+      )
+    } else {
+      investorGrants[address] = getThirdRoundAllocation(amount)
+    }
+  }
+
+  const investorRecipients: Recipient[] = []
+
+  for (const [address, amount] of Object.entries(investorGrants)) {
+    investorRecipients.push({
+      to: address,
+      amount: amount,
+      startTimestamp: TOKEN_LAUNCH_TIMESTAMP,
+      cliffPeriod: BigNumber.from(0),
+      durationPeriod: TWO_YEARS_IN_SEC,
+    })
+  }
+
+  const protocolRecipients: Recipient[] = [
+    // Protocol treasury
+    {
+      to: MULTISIG_ADDRESS,
+      amount: BIG_NUMBER_1E18.mul(300_000_000),
+      startTimestamp: TOKEN_LAUNCH_TIMESTAMP,
+      cliffPeriod: BigNumber.from(0),
+      durationPeriod: THREE_YEARS_IN_SEC,
+    },
+  ]
+
+  const teamRecipients: Recipient[] = [
+    // First batch of team grants
+    {
+      to: "0x27E2E09a84BaE20C2a9667594896EaF132c862b7",
+      amount: BIG_NUMBER_1E18.mul(120_000_000),
+      startTimestamp: FIRST_BATCH_TEAM_VESTING_START_TIMESTAMP,
+      cliffPeriod: BigNumber.from(0),
+      durationPeriod: THREE_YEARS_IN_SEC,
+    },
+    {
+      to: "0xD9AED190e9Ae62b59808537D2EBD9E123eac4703",
+      amount: BIG_NUMBER_1E18.mul(8_000_000),
+      startTimestamp: FIRST_BATCH_TEAM_VESTING_START_TIMESTAMP,
+      cliffPeriod: BigNumber.from(0),
+      durationPeriod: THREE_YEARS_IN_SEC,
+    },
+    {
+      to: "0x82AbEDF193942a6Cdc4704A8D49e54fE51160E99",
+      amount: BIG_NUMBER_1E18.mul(12_000_000),
+      startTimestamp: FIRST_BATCH_TEAM_VESTING_START_TIMESTAMP,
+      cliffPeriod: BigNumber.from(0),
+      durationPeriod: THREE_YEARS_IN_SEC,
+    },
+    // Second batch of team grants
+    {
+      to: "0xc4266Db4A83165Bf1284b564853BFB4DE553C3E1",
+      amount: BIG_NUMBER_1E18.mul(6_500_000),
+      startTimestamp: SECOND_BATCH_TEAM_VESTING_START_TIMESTAMP,
+      cliffPeriod: BigNumber.from(0),
+      durationPeriod: THREE_YEARS_IN_SEC,
+    },
+    {
+      to: "0xcb10D759cAaA8eC12a4D2E59F9d55018Dd8B1C9a",
+      amount: BIG_NUMBER_1E18.mul(8_500_000),
+      startTimestamp: SECOND_BATCH_TEAM_VESTING_START_TIMESTAMP,
+      cliffPeriod: BigNumber.from(0),
+      durationPeriod: THREE_YEARS_IN_SEC,
+    },
+    {
+      to: "0xC13F274e5608C6976463fB401EcAbd7301187937",
+      amount: BIG_NUMBER_1E18.mul(100_000),
+      startTimestamp: SECOND_BATCH_TEAM_VESTING_START_TIMESTAMP,
+      cliffPeriod: BigNumber.from(0),
+      durationPeriod: THREE_YEARS_IN_SEC,
+    },
+    {
+      to: "0xa1fC498f0D5ad41d3d1317Fc1dBcBA54e951a2fb",
+      amount: BIG_NUMBER_1E18.mul(1_900_000),
+      startTimestamp: SECOND_BATCH_TEAM_VESTING_START_TIMESTAMP,
+      cliffPeriod: BigNumber.from(0),
+      durationPeriod: THREE_YEARS_IN_SEC,
+    },
+    // Third batch of team grants
+    {
+      to: "0x6265aaFC8D25B36f97181C44d0EB6693f00EbA17",
+      amount: BIG_NUMBER_1E18.mul(2_000_000),
+      startTimestamp: TOKEN_LAUNCH_TIMESTAMP,
+      cliffPeriod: BigNumber.from(0),
+      durationPeriod: THREE_YEARS_IN_SEC,
+    },
+  ]
+
+  const advisorRecipients: Recipient[] = [
+    // Advisors
+    {
+      to: "0x779492ADFff61f10e224184201979C97Cf7B1ED4",
+      amount: BIG_NUMBER_1E18.mul(2_000_000),
+      startTimestamp: TOKEN_LAUNCH_TIMESTAMP,
+      cliffPeriod: BigNumber.from(0),
+      durationPeriod: THREE_YEARS_IN_SEC,
+    },
+    {
+      to: "0x60063d83E8AB6f2266b6eFcbfa985640CDD3Fc90",
+      amount: BIG_NUMBER_1E18.mul(4_000_000),
+      startTimestamp: TOKEN_LAUNCH_TIMESTAMP,
+      cliffPeriod: BigNumber.from(0),
+      durationPeriod: THREE_YEARS_IN_SEC,
+    },
+  ]
+
+  const encodeRecipients: Recipient[] = [
+    // Encode
+    {
+      to: "0xFABEcA5418bDC3A8289EC0FA5B04edEb1D09c90f",
+      amount: BIG_NUMBER_1E18.mul(2_500_000),
+      startTimestamp: TOKEN_LAUNCH_TIMESTAMP,
+      cliffPeriod: BigNumber.from(0),
+      durationPeriod: THREE_YEARS_IN_SEC,
+    },
+  ]
+
+  const thesisRecipients: Recipient[] = [
+    // Thesis
+    {
+      to: "0x53AB8F38EE493d88553Ea6c2766d574E404e249B",
+      amount: BIG_NUMBER_1E18.mul(100_000_000),
+      startTimestamp: TOKEN_LAUNCH_TIMESTAMP,
+      cliffPeriod: BigNumber.from(0),
+      durationPeriod: THREE_YEARS_IN_SEC,
+    },
+  ]
+
+  const unexercisedWarrantRecipients = [
+    // Vesting for un-exercised warrants
+    {
+      to: MULTISIG_ADDRESS,
+      amount: getFirstRoundAllocation(10000),
+      startTimestamp: TOKEN_LAUNCH_TIMESTAMP,
+      cliffPeriod: BigNumber.from(0),
+      durationPeriod: TWO_YEARS_IN_SEC,
+    },
+    {
+      to: MULTISIG_ADDRESS,
+      amount: getSecondRoundAllocation(25000),
+      startTimestamp: TOKEN_LAUNCH_TIMESTAMP,
+      cliffPeriod: BigNumber.from(0),
+      durationPeriod: TWO_YEARS_IN_SEC,
+    },
+    {
+      to: MULTISIG_ADDRESS,
+      amount: getSecondRoundAllocation(25000),
+      startTimestamp: TOKEN_LAUNCH_TIMESTAMP,
+      cliffPeriod: BigNumber.from(0),
+      durationPeriod: TWO_YEARS_IN_SEC,
+    },
+  ]
+
+  let totalAdvisorAmount = BigNumber.from(0)
+  for (const recipient of advisorRecipients) {
+    totalAdvisorAmount = totalAdvisorAmount.add(recipient.amount)
+  }
+  console.assert(
+    totalAdvisorAmount.eq(BIG_NUMBER_1E18.mul(6_000_000)),
+    `amounts did not match (got, expected): ${totalAdvisorAmount}, ${BIG_NUMBER_1E18.mul(
+      6_000_000,
+    )}`,
+  )
+
+  let totalTeamAmount = BigNumber.from(0)
+  for (const recipient of [...teamRecipients, ...thesisRecipients]) {
+    totalTeamAmount = totalTeamAmount.add(recipient.amount)
+  }
+  console.assert(
+    totalTeamAmount.eq(BIG_NUMBER_1E18.mul(259_000_000)),
+    `team amounts did not match (got, expected): ${totalTeamAmount}, ${BIG_NUMBER_1E18.mul(
+      259_000_000,
+    )}`,
+  )
+
+  let totalInvestorAmount = BigNumber.from(0)
+  for (const recipient of [
+    ...investorRecipients,
+    ...unexercisedWarrantRecipients,
+  ]) {
+    totalInvestorAmount = totalInvestorAmount.add(recipient.amount)
+  }
+  console.assert(
+    totalInvestorAmount.eq(BIG_NUMBER_1E18.mul(225_000_000)),
+    `investor amounts did not match (got, expected): ${totalInvestorAmount}, ${BIG_NUMBER_1E18.mul(
+      225_000_000,
+    )}`,
+  )
+
+  const vestingRecipients: Recipient[] = [
+    ...protocolRecipients,
+    ...teamRecipients,
+    ...advisorRecipients,
+    ...encodeRecipients,
+    ...thesisRecipients,
+    ...investorRecipients,
+    ...unexercisedWarrantRecipients,
+  ]
+
+  // Approve the contract to use the token for deploying the vesting contracts
+  await execute(
+    "SDL",
+    { from: deployer, log: true },
+    "approve",
+    (
+      await get("SDL")
+    ).address,
+    MAX_UINT256,
+  )
+
+  // Deploy a new vesting contract clone for each recipient
+  for (const recipient of vestingRecipients) {
+    await execute(
+      "SDL",
+      {
+        from: deployer,
+        log: true,
+      },
+      "deployNewVestingContract",
+      recipient,
+    )
+  }
+}
+export default func
+func.tags = ["VestingClones"]
+func.skip = async (env) => true

--- a/deploy/hardhat/303_deploy_RetroactiveVesting.ts
+++ b/deploy/hardhat/303_deploy_RetroactiveVesting.ts
@@ -1,0 +1,39 @@
+import { BIG_NUMBER_1E18, isTestNetwork } from "../../test/testUtils"
+
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, get, execute, getOrNull } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  if ((await getOrNull("RetroactiveVesting")) == null) {
+    // Deploy retroactive vesting contract for airdrops
+    await deploy("RetroactiveVesting", {
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+      args: [
+        (await get("SDL")).address,
+        isTestNetwork(await getChainId())
+          ? "0xd6a1b52194896b83e8872ba351a81ad70f78258c4f9575c1f4c6d24090b05a5e"
+          : "0x235d88efaae4e04494277ca85279b0550806a2b3efb124e38933a167ba4e7cec",
+        1637042400, // Tuesday, November 16, 2021 6:00:00 AM
+      ],
+    })
+
+    // Transfer 150_000_000 SDL tokens to the retroactive vesting contract
+    await execute(
+      "SDL",
+      { from: deployer, log: true },
+      "transfer",
+      (
+        await get("RetroactiveVesting")
+      ).address,
+      BIG_NUMBER_1E18.mul(150_000_000),
+    )
+  }
+}
+export default func
+func.tags = ["RetroactiveVesting"]

--- a/deploy/hardhat/304_deploy_MiniChef.ts
+++ b/deploy/hardhat/304_deploy_MiniChef.ts
@@ -1,0 +1,90 @@
+import { BIG_NUMBER_1E18 } from "../../test/testUtils"
+
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { MiniChefV2 } from "../../build/typechain"
+import { ethers } from "hardhat"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, get, execute, getOrNull } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  if ((await getOrNull("MiniChefV2")) == null) {
+    // Deploy retroactive vesting contract for airdrops
+    await deploy("MiniChefV2", {
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+      args: [(await get("SDL")).address],
+    })
+
+    const minichef: MiniChefV2 = await ethers.getContract("MiniChefV2")
+
+    // Total LM rewards is 30,000,000 but only 12,500,000 is allocated in the beginning
+    const TOTAL_LM_REWARDS = BIG_NUMBER_1E18.mul(12_500_000)
+    // 6 months (24 weeks)
+    const lmRewardsPerSecond = TOTAL_LM_REWARDS.div(6 * 4 * 7 * 24 * 3600)
+
+    const batchCall = [
+      await minichef.populateTransaction.setSaddlePerSecond(lmRewardsPerSecond),
+      await minichef.populateTransaction.add(
+        1,
+        "0x0000000000000000000000000000000000000000", // blank lp token to enforce totalAllocPoint != 0
+        "0x0000000000000000000000000000000000000000",
+      ),
+      await minichef.populateTransaction.add(
+        0,
+        (
+          await get("SaddleALETHPoolLPToken")
+        ).address,
+        "0x0000000000000000000000000000000000000000",
+      ),
+      await minichef.populateTransaction.add(
+        0,
+        (
+          await get("SaddleD4PoolLPToken")
+        ).address,
+        "0x0000000000000000000000000000000000000000",
+      ),
+      await minichef.populateTransaction.add(
+        0,
+        (
+          await get("SaddleUSDPoolV2LPToken")
+        ).address,
+        "0x0000000000000000000000000000000000000000",
+      ),
+      await minichef.populateTransaction.add(
+        0,
+        (
+          await get("SaddleBTCPoolV2LPToken")
+        ).address,
+        "0x0000000000000000000000000000000000000000",
+      ),
+    ]
+
+    const batchCallData = batchCall.map((x) => x.data)
+
+    // Send batch call
+    await execute(
+      "MiniChefV2",
+      { from: deployer, log: true },
+      "batch",
+      batchCallData,
+      false,
+    )
+
+    // Transfer 1 month worth of LM rewards to MiniChefV2
+    await execute(
+      "SDL",
+      { from: deployer, log: true },
+      "transfer",
+      (
+        await get("MiniChefV2")
+      ).address,
+      TOTAL_LM_REWARDS.div(6),
+    )
+  }
+}
+export default func
+func.tags = ["MiniChef"]

--- a/deploy/hardhat/400_execute_addToAllowedList.ts
+++ b/deploy/hardhat/400_execute_addToAllowedList.ts
@@ -1,0 +1,19 @@
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { CHAIN_ID } from "../../utils/network"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, execute, get } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  await execute("SDL", { from: deployer, log: true }, "addToAllowedList", [
+    (await get("RetroactiveVesting")).address,
+    (await get("MiniChefV2")).address,
+    // Saddle grants multisig
+    "0x87f194b4175d415E399E5a77fCfdFA66040199b6",
+  ])
+}
+export default func
+func.tags = ["addToAllowedList"]
+func.skip = async (hre) => (await hre.getChainId()) !== CHAIN_ID.HARDHAT

--- a/deploy/hardhat/410_check_KEEP.ts
+++ b/deploy/hardhat/410_check_KEEP.ts
@@ -1,0 +1,37 @@
+import { BigNumber } from "ethers"
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { isTestNetwork } from "../../utils/network"
+
+const TOKENS_ARGS: { [token: string]: any[] } = {
+  KEEP: ["KEEP token", "KEEP", "18"],
+}
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, execute } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  for (const token in TOKENS_ARGS) {
+    await deploy(token, {
+      from: deployer,
+      log: true,
+      contract: "GenericERC20",
+      args: TOKENS_ARGS[token],
+      skipIfAlreadyDeployed: true,
+    })
+    // If it's on hardhat, mint test tokens
+    if (isTestNetwork(await getChainId())) {
+      const decimals = TOKENS_ARGS[token][2]
+      await execute(
+        token,
+        { from: deployer, log: true },
+        "mint",
+        deployer,
+        BigNumber.from(10).pow(decimals).mul(1000000),
+      )
+    }
+  }
+}
+export default func
+func.tags = ["KEEPToken"]

--- a/deploy/hardhat/411_deploy_SimpleRewarder_KEEP.ts
+++ b/deploy/hardhat/411_deploy_SimpleRewarder_KEEP.ts
@@ -1,0 +1,65 @@
+import { expect } from "chai"
+import { BigNumber } from "ethers"
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { ZERO_ADDRESS } from "../../test/testUtils"
+import { CHAIN_ID } from "../../utils/network"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId, ethers } = hre
+  const { deploy, execute, get, getOrNull, save, read } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  if ((await getOrNull("SimpleRewarder")) == null) {
+    const result = await deploy("SimpleRewarder", {
+      from: deployer,
+      log: true,
+      args: [(await get("MiniChefV2")).address],
+      skipIfAlreadyDeployed: true,
+    })
+
+    await save("SimpleRewarder_KEEP", result)
+
+    const PID = 5
+    const tbtcMetaPoolLpToken = (await get("SaddleTBTCMetaPoolUpdatedLPToken"))
+      .address
+    const rewardToken = (await get("KEEP")).address // KEEP token
+    const rewardAdmin = "0xb78c0cf4c9e9bf4ba24b17065fa8c0ac71957653" // KEEP team's OpEx wallet
+    const rewardPerSecond = BigNumber.from("413359788359788360") // 250k KEEP weekly
+
+    // Ensure LP token is added to MiniChefV2, uses arbitrary allocpoint
+    if ((await getChainId()) == CHAIN_ID.HARDHAT)
+      await execute(
+        "MiniChefV2",
+        { from: deployer, log: true },
+        "add",
+        1,
+        tbtcMetaPoolLpToken,
+        ZERO_ADDRESS,
+      )
+
+    // Ensure pid is correct
+    expect(await read("MiniChefV2", "lpToken", PID)).to.eq(tbtcMetaPoolLpToken)
+
+    // (IERC20 rewardToken, address owner, uint256 rewardPerSecond, IERC20 masterLpToken, uint256 pid)
+    const data = ethers.utils.defaultAbiCoder.encode(
+      ["address", "address", "uint256", "address", "uint256"],
+      [
+        rewardToken, // KEEP token
+        rewardAdmin, // KEEP team's OpEx wallet
+        rewardPerSecond, // 250k KEEP weekly
+        tbtcMetaPoolLpToken, // master LP token
+        PID, // pid
+      ],
+    )
+
+    await execute(
+      "SimpleRewarder_KEEP",
+      { from: deployer, log: true },
+      "init",
+      data,
+    )
+  }
+}
+export default func
+func.tags = ["SimpleRewarder_KEEP"]

--- a/deploy/hardhat/420_check_T.ts
+++ b/deploy/hardhat/420_check_T.ts
@@ -1,0 +1,37 @@
+import { BigNumber } from "ethers"
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { isTestNetwork } from "../../utils/network"
+
+const TOKENS_ARGS: { [token: string]: any[] } = {
+  T: ["Threshold Network token", "T", "18"],
+}
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, execute } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  for (const token in TOKENS_ARGS) {
+    await deploy(token, {
+      from: deployer,
+      log: true,
+      contract: "GenericERC20",
+      args: TOKENS_ARGS[token],
+      skipIfAlreadyDeployed: true,
+    })
+    // If it's on hardhat, mint test tokens
+    if (isTestNetwork(await getChainId())) {
+      const decimals = TOKENS_ARGS[token][2]
+      await execute(
+        token,
+        { from: deployer, log: true },
+        "mint",
+        deployer,
+        BigNumber.from(10).pow(decimals).mul(1000000),
+      )
+    }
+  }
+}
+export default func
+func.tags = ["T"]

--- a/deploy/hardhat/421_deploy_SimpleRewarder_T.ts
+++ b/deploy/hardhat/421_deploy_SimpleRewarder_T.ts
@@ -1,0 +1,64 @@
+import { expect } from "chai"
+import { BigNumber } from "ethers"
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { ZERO_ADDRESS } from "../../test/testUtils"
+import { CHAIN_ID } from "../../utils/network"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId, ethers } = hre
+  const { deploy, execute, get, getOrNull, save, read } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  if ((await getOrNull("SimpleRewarder_T")) == null) {
+    await deploy("SimpleRewarder_T", {
+      from: deployer,
+      log: true,
+      contract: "SimpleRewarder",
+      args: [(await get("MiniChefV2")).address],
+      skipIfAlreadyDeployed: true,
+    })
+
+    const PID = 5
+    const tbtcMetaPoolLpToken = (await get("SaddleTBTCMetaPoolUpdatedLPToken"))
+      .address
+    const rewardToken = (await get("T")).address // KEEP token
+    const rewardAdmin = "0xb78c0cf4c9e9bf4ba24b17065fa8c0ac71957653" // KEEP team's OpEx wallet
+    const rewardPerSecond = BigNumber.from("413359788359788360") // 250k KEEP weekly
+
+    // Ensure LP token is added to MiniChefV2, uses arbitrary allocpoint
+    if ((await getChainId()) == CHAIN_ID.HARDHAT)
+      await execute(
+        "MiniChefV2",
+        { from: deployer, log: true },
+        "add",
+        1,
+        tbtcMetaPoolLpToken,
+        ZERO_ADDRESS,
+      )
+
+    // Ensure pid is correct
+    expect(await read("MiniChefV2", "lpToken", PID)).to.eq(tbtcMetaPoolLpToken)
+
+    // (IERC20 rewardToken, address owner, uint256 rewardPerSecond, IERC20 masterLpToken, uint256 pid)
+    const data = ethers.utils.defaultAbiCoder.encode(
+      ["address", "address", "uint256", "address", "uint256"],
+      [
+        rewardToken, // KEEP token
+        rewardAdmin, // KEEP team's OpEx wallet
+        rewardPerSecond, // 250k KEEP weekly
+        tbtcMetaPoolLpToken, // master LP token
+        PID, // pid
+      ],
+    )
+
+    await execute(
+      "SimpleRewarder_T",
+      { from: deployer, log: true },
+      "init",
+      data,
+    )
+  }
+}
+export default func
+func.tags = ["SimpleRewarder_T"]

--- a/deploy/hardhat/430_deploy_SwapCalculator.ts
+++ b/deploy/hardhat/430_deploy_SwapCalculator.ts
@@ -1,0 +1,17 @@
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId, ethers } = hre
+  const { deploy, execute, get, getOrNull, save, read } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  await deploy("SwapCalculator", {
+    from: deployer,
+    log: true,
+    contract: "SwapCalculator",
+    skipIfAlreadyDeployed: true,
+  })
+}
+export default func
+func.tags = ["SwapCalculator"]

--- a/deploy/hardhat/440_deploy_PoolRegistry.ts
+++ b/deploy/hardhat/440_deploy_PoolRegistry.ts
@@ -1,0 +1,21 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { MULTISIG_ADDRESSES } from "../../utils/accounts"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const chaindId = await getChainId()
+
+  await deploy("PoolRegistry", {
+    from: deployer,
+    log: true,
+    skipIfAlreadyDeployed: true,
+    args: [deployer, MULTISIG_ADDRESSES[chaindId]],
+  })
+  // NOTE: manager role is given to deployer and admin role to multisig
+}
+export default func
+func.tags = ["PoolRegistry"]

--- a/deploy/hardhat/441_deploy_MasterRegistry.ts
+++ b/deploy/hardhat/441_deploy_MasterRegistry.ts
@@ -1,0 +1,52 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { MULTISIG_ADDRESSES } from "../../utils/accounts"
+import { MasterRegistry } from "../../build/typechain"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId, ethers } = hre
+  const { deploy, get, getOrNull, execute, read } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const masterRegistry = await getOrNull("MasterRegistry")
+
+  if (masterRegistry == null) {
+    await deploy("MasterRegistry", {
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+      args: [MULTISIG_ADDRESSES[await getChainId()]],
+    })
+
+    const contract = (await ethers.getContract(
+      "MasterRegistry",
+    )) as MasterRegistry
+
+    const batchCall = [
+      await contract.populateTransaction.addRegistry(
+        ethers.utils.formatBytes32String("PoolRegistry"),
+        (
+          await get("PoolRegistry")
+        ).address,
+      ),
+      await contract.populateTransaction.addRegistry(
+        ethers.utils.formatBytes32String("FeeCollector"),
+        MULTISIG_ADDRESSES[await getChainId()],
+      ),
+    ]
+
+    const batchCallData = batchCall
+      .map((x) => x.data)
+      .filter((x): x is string => !!x)
+
+    await execute(
+      "MasterRegistry",
+      { from: deployer, log: true },
+      "batch",
+      batchCallData,
+      true,
+    )
+  }
+}
+export default func
+func.tags = ["MasterRegistry"]

--- a/deploy/hardhat/442_add_to_PoolRegistry.ts
+++ b/deploy/hardhat/442_add_to_PoolRegistry.ts
@@ -1,0 +1,196 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { PoolRegistry } from "../../build/typechain"
+import { ZERO_ADDRESS } from "../../test/testUtils"
+import { PoolType } from "../../utils/constants"
+import { IPoolRegistry } from "../../build/typechain/"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId, ethers } = hre
+  const { deploy, get, getOrNull, execute, read, log } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const poolRegistry: PoolRegistry = await ethers.getContract("PoolRegistry")
+
+  await poolRegistry
+    .getPoolDataByName(ethers.utils.formatBytes32String("USDv2"))
+    .then(() => {
+      log("Skipping adding pools to registry because they are already added")
+    })
+    .catch(async () => {
+      log("Adding pools to registry")
+      const pools: IPoolRegistry.PoolInputDataStruct[] = [
+        {
+          // USDv2 pool
+          poolAddress: (await get("SaddleUSDPoolV2")).address,
+          typeOfAsset: PoolType.USD,
+          poolName: ethers.utils.formatBytes32String("USDv2"),
+          targetAddress: (await get("SwapFlashLoan")).address,
+          metaSwapDepositAddress: ZERO_ADDRESS,
+          isSaddleApproved: true,
+          isRemoved: false,
+          isGuarded: false,
+        },
+        {
+          // D4 pool
+          poolAddress: (await get("SaddleD4Pool")).address,
+          typeOfAsset: PoolType.USD,
+          poolName: ethers.utils.formatBytes32String("D4"),
+          targetAddress: (await get("SwapFlashLoan")).address,
+          metaSwapDepositAddress: ZERO_ADDRESS,
+          isSaddleApproved: true,
+          isRemoved: false,
+          isGuarded: false,
+        },
+        {
+          // BTCv2 pool
+          poolAddress: (await get("SaddleBTCPoolV2")).address,
+          typeOfAsset: PoolType.BTC,
+          poolName: ethers.utils.formatBytes32String("BTCv2"),
+          targetAddress: (await get("SwapFlashLoan")).address,
+          metaSwapDepositAddress: ZERO_ADDRESS,
+          isSaddleApproved: true,
+          isRemoved: false,
+          isGuarded: false,
+        },
+        {
+          // alETH pool
+          poolAddress: (await get("SaddleALETHPool")).address,
+          typeOfAsset: PoolType.ETH,
+          poolName: ethers.utils.formatBytes32String("alETH"),
+          targetAddress: (await get("SwapFlashLoan")).address,
+          metaSwapDepositAddress: ZERO_ADDRESS,
+          isSaddleApproved: true,
+          isRemoved: false,
+          isGuarded: false,
+        },
+        {
+          // tBTCv2 meta pool updated
+          poolAddress: (await get("SaddleTBTCMetaPoolUpdated")).address,
+          typeOfAsset: PoolType.BTC,
+          poolName: ethers.utils.formatBytes32String("tBTCv2-BTCv2"),
+          targetAddress: (await get("MetaSwapUpdated")).address,
+          metaSwapDepositAddress: (
+            await get("SaddleTBTCMetaPoolUpdatedDeposit")
+          ).address,
+          isSaddleApproved: true,
+          isRemoved: false,
+          isGuarded: false,
+        },
+        {
+          // sUSD meta pool updated
+          poolAddress: (await get("SaddleSUSDMetaPoolUpdated")).address,
+          typeOfAsset: PoolType.USD,
+          poolName: ethers.utils.formatBytes32String("sUSD-USDv2"),
+          targetAddress: (await get("MetaSwapUpdated")).address,
+          metaSwapDepositAddress: (
+            await get("SaddleSUSDMetaPoolUpdatedDeposit")
+          ).address,
+          isSaddleApproved: true,
+          isRemoved: false,
+          isGuarded: false,
+        },
+        {
+          // WCUSD meta pool updated
+          poolAddress: (await get("SaddleWCUSDMetaPoolUpdated")).address,
+          typeOfAsset: PoolType.USD,
+          poolName: ethers.utils.formatBytes32String("WCUSD-USDv2"),
+          targetAddress: (await get("MetaSwapUpdated")).address,
+          metaSwapDepositAddress: (
+            await get("SaddleWCUSDMetaPoolUpdatedDeposit")
+          ).address,
+          isSaddleApproved: true,
+          isRemoved: false,
+          isGuarded: false,
+        },
+        {
+          // vETH2 pool
+          poolAddress: (await get("SaddleVETH2Pool")).address,
+          typeOfAsset: PoolType.ETH,
+          poolName: ethers.utils.formatBytes32String("vETH2"),
+          targetAddress: "0x5847f8177221268d279Cf377D0E01aB3FD993628",
+          metaSwapDepositAddress: ZERO_ADDRESS,
+          isSaddleApproved: true,
+          isRemoved: false,
+          isGuarded: false,
+        },
+        {
+          // BTC pool
+          poolAddress: (await get("SaddleBTCPool")).address,
+          typeOfAsset: PoolType.BTC,
+          poolName: ethers.utils.formatBytes32String("BTC"),
+          targetAddress: (await get("SaddleBTCPool")).address,
+          metaSwapDepositAddress: ZERO_ADDRESS,
+          isSaddleApproved: true,
+          isRemoved: true,
+          isGuarded: true,
+        },
+        {
+          // USD pool
+          poolAddress: (await get("SaddleUSDPool")).address,
+          typeOfAsset: PoolType.USD,
+          poolName: ethers.utils.formatBytes32String("USD"),
+          targetAddress: "0x98D2aFc66DE1F73598c6CFa35cbdfebB135fb8FA",
+          metaSwapDepositAddress: ZERO_ADDRESS,
+          isSaddleApproved: true,
+          isRemoved: true,
+          isGuarded: false,
+        },
+        {
+          // sUSD meta pool updated
+          poolAddress: (await get("SaddleSUSDMetaPool")).address,
+          typeOfAsset: PoolType.USD,
+          poolName: ethers.utils.formatBytes32String("sUSD-USDv2_outdated"),
+          targetAddress: (await get("SaddleSUSDMetaPool")).address,
+          metaSwapDepositAddress: (await get("SaddleSUSDMetaPoolDeposit"))
+            .address,
+          isSaddleApproved: true,
+          isRemoved: true,
+          isGuarded: false,
+        },
+        {
+          // tBTCv2 meta pool updated
+          poolAddress: (await get("SaddleTBTCMetaPool")).address,
+          typeOfAsset: PoolType.BTC,
+          poolName: ethers.utils.formatBytes32String("tBTCv2-BTCv2_outdated"),
+          targetAddress: (await get("SaddleSUSDMetaPool")).address,
+          metaSwapDepositAddress: (await get("SaddleTBTCMetaPoolDeposit"))
+            .address,
+          isSaddleApproved: true,
+          isRemoved: true,
+          isGuarded: false,
+        },
+        {
+          // WCUSD meta pool updated
+          poolAddress: (await get("SaddleWCUSDMetaPool")).address,
+          typeOfAsset: PoolType.USD,
+          poolName: ethers.utils.formatBytes32String("WCUSD-USDv2_outdated"),
+          targetAddress: (await get("SaddleWCUSDMetaPool")).address,
+          metaSwapDepositAddress: (await get("SaddleWCUSDMetaPoolDeposit"))
+            .address,
+          isSaddleApproved: true,
+          isRemoved: true,
+          isGuarded: false,
+        },
+      ]
+
+      const batchCall = await Promise.all(
+        pools.map(
+          async (pool) => await poolRegistry.populateTransaction.addPool(pool),
+        ),
+      )
+
+      const batchCallData = batchCall
+        .map((x) => x.data)
+        .filter((x): x is string => !!x)
+
+      await execute(
+        "PoolRegistry",
+        { from: deployer, log: true },
+        "batch",
+        batchCallData,
+        true,
+      )
+    })
+}
+export default func

--- a/deploy/hardhat/450_deploy_PermissionlessSwaps.ts
+++ b/deploy/hardhat/450_deploy_PermissionlessSwaps.ts
@@ -1,0 +1,112 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { MULTISIG_ADDRESSES } from "../../utils/accounts"
+import { PoolRegistry } from "../../build/typechain"
+import dotenv from "dotenv"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  dotenv.config()
+  const { deployments, getNamedAccounts, getChainId, ethers } = hre
+  const { deploy, get, getOrNull, execute } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const permissionlessSwap = await getOrNull("PermissionlessSwapFlashLoan")
+  const permissionlessMetaSwap = await getOrNull(
+    "PermissionlessMetaSwapFlashLoan",
+  )
+  const permissionlessDeployer = await getOrNull("PermissionlessDeployer")
+  const masterRegistryAddress = (await get("MasterRegistry")).address
+
+  if (permissionlessSwap == null) {
+    await deploy("PermissionlessSwapFlashLoan", {
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+      args: [masterRegistryAddress],
+      libraries: {
+        SwapUtils: (await get("SwapUtils")).address,
+        AmplificationUtils: (await get("AmplificationUtils")).address,
+      },
+    })
+  }
+
+  if (permissionlessMetaSwap == null) {
+    await deploy("PermissionlessMetaSwapFlashLoan", {
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+      args: [masterRegistryAddress],
+      libraries: {
+        SwapUtils: (await get("SwapUtils")).address,
+        MetaSwapUtils: (await get("MetaSwapUtils")).address,
+        AmplificationUtils: (await get("AmplificationUtils")).address,
+      },
+    })
+  }
+
+  if (permissionlessDeployer == null) {
+    await deploy("PermissionlessDeployer", {
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+      args: [
+        MULTISIG_ADDRESSES[await getChainId()],
+        (await get("MasterRegistry")).address,
+        (await get("LPToken")).address,
+        (await get("PermissionlessSwapFlashLoan")).address,
+        (await get("PermissionlessMetaSwapFlashLoan")).address,
+        (await get("SaddleSUSDMetaPoolDeposit")).address,
+      ],
+    })
+
+    await execute(
+      "MasterRegistry",
+      {
+        from: deployer,
+        log: true,
+      },
+      "addRegistry",
+      ethers.utils.formatBytes32String("PermissionlessDeployer"),
+      (
+        await get("PermissionlessDeployer")
+      ).address,
+    )
+
+    const poolRegistry: PoolRegistry = await ethers.getContract("PoolRegistry")
+
+    // 1. Grant COMMUNITY_MANAGER_ROLE to PermissionlessDeployer
+    // 2. Grant COMMUNITY_MANAGER_ROLE to deployer account
+    // 3. Grant DEFAULT_ADMIN_ROLE to Multisig on this chain
+    const batchCall = [
+      await poolRegistry.populateTransaction.grantRole(
+        await poolRegistry.COMMUNITY_MANAGER_ROLE(),
+        (
+          await get("PermissionlessDeployer")
+        ).address,
+      ),
+      await poolRegistry.populateTransaction.grantRole(
+        await poolRegistry.COMMUNITY_MANAGER_ROLE(),
+        deployer,
+      ),
+      await poolRegistry.populateTransaction.grantRole(
+        await poolRegistry.DEFAULT_ADMIN_ROLE(),
+        MULTISIG_ADDRESSES[await getChainId()],
+      ),
+    ]
+
+    const batchCallData = batchCall
+      .map((x) => x.data)
+      .filter((x): x is string => !!x)
+
+    await execute(
+      "PoolRegistry",
+      { from: deployer, log: true },
+      "batch",
+      batchCallData,
+      true,
+    )
+  }
+}
+export default func
+func.tags = ["PermissionlessSwaps"]
+// func.skip = async (env) => (await env.getChainId()) == CHAIN_ID.MAINNET

--- a/deploy/hardhat/460_deploy_SUSDMetaPoolV3.ts
+++ b/deploy/hardhat/460_deploy_SUSDMetaPoolV3.ts
@@ -1,0 +1,92 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { MULTISIG_ADDRESSES } from "../../utils/accounts"
+
+// Deployment names
+const META_POOL_NAME = "SaddleSUSDMetaPoolV3"
+const META_POOL_LP_TOKEN_NAME = `${META_POOL_NAME}LPToken`
+const BASE_POOL_NAME = "SaddleUSDPoolV2"
+
+// Constructor arguments
+const TOKEN_NAMES = ["SUSD", `${BASE_POOL_NAME}LPToken`]
+const TOKEN_DECIMALS = [18, 18]
+const LP_TOKEN_NAME = "Saddle sUSD/saddleUSD-V2 V3 LP Token"
+const LP_TOKEN_SYMBOL = "saddleSUSD-V3"
+const INITIAL_A = 100
+const SWAP_FEE = 4e6 // 4bps
+const ADMIN_FEE = 50e8
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { execute, deploy, get, getOrNull, log, read, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const metaPool = await getOrNull(META_POOL_NAME)
+  if (metaPool) {
+    log(`reusing ${META_POOL_NAME} at ${metaPool.address}`)
+  } else {
+    const TOKEN_ADDRESSES = await Promise.all(
+      TOKEN_NAMES.map(async (name) => (await get(name)).address),
+    )
+
+    await deploy(META_POOL_NAME, {
+      from: deployer,
+      log: true,
+      contract: "MetaSwap",
+      skipIfAlreadyDeployed: true,
+      libraries: {
+        SwapUtils: (await get("SwapUtils")).address,
+        MetaSwapUtils: (await get("MetaSwapUtils")).address,
+        AmplificationUtils: (await get("AmplificationUtils")).address,
+      },
+    })
+
+    await save("MetaSwapV3", await get(META_POOL_NAME))
+
+    await execute(
+      META_POOL_NAME,
+      {
+        from: deployer,
+        log: true,
+      },
+      "initializeMetaSwap",
+      TOKEN_ADDRESSES,
+      TOKEN_DECIMALS,
+      LP_TOKEN_NAME,
+      LP_TOKEN_SYMBOL,
+      INITIAL_A,
+      SWAP_FEE,
+      ADMIN_FEE,
+      (
+        await get("LPToken")
+      ).address,
+      (
+        await get(BASE_POOL_NAME)
+      ).address,
+    )
+
+    await execute(
+      META_POOL_NAME,
+      { from: deployer, log: true },
+      "transferOwnership",
+      MULTISIG_ADDRESSES[await getChainId()],
+    )
+
+    const lpTokenAddress = (await read(META_POOL_NAME, "swapStorage")).lpToken
+    log(`deployed ${META_POOL_LP_TOKEN_NAME} at ${lpTokenAddress}`)
+
+    await save(`${META_POOL_LP_TOKEN_NAME}`, {
+      abi: (await get("LPToken")).abi, // LPToken ABI
+      address: lpTokenAddress,
+    })
+  }
+}
+export default func
+func.tags = [META_POOL_NAME]
+func.dependencies = [
+  "SUSDMetaPoolTokens",
+  "USDPoolV2",
+  "MetaSwapUtils",
+  "AmplificationUtils",
+]

--- a/deploy/hardhat/461_deploy_SUSDMetaPoolV3Deposit.ts
+++ b/deploy/hardhat/461_deploy_SUSDMetaPoolV3Deposit.ts
@@ -1,0 +1,63 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+// Deployment names
+const META_POOL_NAME = "SaddleSUSDMetaPoolV3"
+const META_POOL_LP_TOKEN_NAME = `${META_POOL_NAME}LPToken`
+const META_POOL_DEPOSIT_NAME = `${META_POOL_NAME}Deposit`
+const TARGET_META_SWAP_DEPOSIT_NAME = `MetaSwapDeposit`
+const BASE_POOL_NAME = `SaddleUSDPoolV2`
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, get, getOrNull, log, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const metaPoolDeposit = await getOrNull(META_POOL_DEPOSIT_NAME)
+  if (metaPoolDeposit) {
+    log(`reusing ${META_POOL_DEPOSIT_NAME} at ${metaPoolDeposit.address}`)
+  } else {
+    const receipt = await execute(
+      "SwapDeployer",
+      {
+        from: deployer,
+        log: true,
+      },
+      "clone",
+      (
+        await get(TARGET_META_SWAP_DEPOSIT_NAME)
+      ).address,
+    )
+
+    const newPoolEvent = receipt?.events?.find(
+      (e: any) => e["event"] === "NewClone",
+    )
+    const deployedAddress = newPoolEvent["args"]["cloneAddress"]
+    log(
+      `deployed ${META_POOL_DEPOSIT_NAME} (targeting ${TARGET_META_SWAP_DEPOSIT_NAME}) at ${deployedAddress}`,
+    )
+    await save(META_POOL_DEPOSIT_NAME, {
+      abi: (await get(TARGET_META_SWAP_DEPOSIT_NAME)).abi,
+      address: deployedAddress,
+    })
+
+    await execute(
+      META_POOL_DEPOSIT_NAME,
+      { from: deployer, log: true, gasLimit: 1_000_000 },
+      "initialize",
+      (
+        await get(BASE_POOL_NAME)
+      ).address,
+      (
+        await get(META_POOL_NAME)
+      ).address,
+      (
+        await get(META_POOL_LP_TOKEN_NAME)
+      ).address,
+    )
+  }
+}
+export default func
+func.tags = [META_POOL_DEPOSIT_NAME]
+func.dependencies = ["SUSDMetaPoolTokens", META_POOL_NAME]

--- a/deploy/hardhat/462_deploy_TBTCMetaPoolV3.ts
+++ b/deploy/hardhat/462_deploy_TBTCMetaPoolV3.ts
@@ -1,0 +1,80 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+// Deployment names
+const META_POOL_NAME = "SaddleTBTCMetaPoolV3"
+const META_POOL_LP_TOKEN_NAME = `${META_POOL_NAME}LPToken`
+const BASE_POOL_NAME = "SaddleBTCPoolV2"
+
+// Constructor arguments
+const TOKEN_NAMES = ["TBTCv2", `${BASE_POOL_NAME}LPToken`]
+const TOKEN_DECIMALS = [18, 18]
+const LP_TOKEN_NAME = "Saddle tBTCv2/saddleWRenSBTC V3 LP Token"
+const LP_TOKEN_SYMBOL = "saddleTBTC-V3"
+const INITIAL_A = 100
+const SWAP_FEE = 4e6 // 4bps
+const ADMIN_FEE = 50e8
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, get, getOrNull, log, read, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const metaPool = await getOrNull(META_POOL_NAME)
+  if (metaPool) {
+    log(`reusing ${META_POOL_NAME} at ${metaPool.address}`)
+  } else {
+    const TOKEN_ADDRESSES = await Promise.all(
+      TOKEN_NAMES.map(async (name) => (await get(name)).address),
+    )
+
+    const receipt = await execute(
+      "SwapDeployer",
+      {
+        from: deployer,
+        log: true,
+      },
+      "deployMetaSwap",
+      (
+        await get("MetaSwapV3")
+      ).address,
+      TOKEN_ADDRESSES,
+      TOKEN_DECIMALS,
+      LP_TOKEN_NAME,
+      LP_TOKEN_SYMBOL,
+      INITIAL_A,
+      SWAP_FEE,
+      ADMIN_FEE,
+      (
+        await get("LPToken")
+      ).address,
+      (
+        await get(BASE_POOL_NAME)
+      ).address,
+    )
+
+    const newPoolEvent = receipt?.events?.find(
+      (e: any) => e["event"] === "NewSwapPool",
+    )
+    const deployedAddress = newPoolEvent["args"]["swapAddress"]
+    log(
+      `deployed ${META_POOL_NAME} (targeting "MetaSwapV3") at ${deployedAddress}`,
+    )
+    await save(META_POOL_NAME, {
+      abi: (await get("MetaSwapV3")).abi,
+      address: deployedAddress,
+    })
+
+    const lpTokenAddress = (await read(META_POOL_NAME, "swapStorage")).lpToken
+    log(`deployed ${META_POOL_LP_TOKEN_NAME} at ${lpTokenAddress}`)
+
+    await save(META_POOL_LP_TOKEN_NAME, {
+      abi: (await get("LPToken")).abi, // LPToken ABI
+      address: lpTokenAddress,
+    })
+  }
+}
+export default func
+func.tags = [META_POOL_NAME]
+func.dependencies = ["LPToken", "TBTCMetaPoolTokens", "BTCPoolV2"]

--- a/deploy/hardhat/463_deploy_TBTCMetaPoolV3Deposit.ts
+++ b/deploy/hardhat/463_deploy_TBTCMetaPoolV3Deposit.ts
@@ -1,0 +1,63 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+// Deployment names
+const META_POOL_NAME = "SaddleTBTCMetaPoolV3"
+const META_POOL_LP_TOKEN_NAME = `${META_POOL_NAME}LPToken`
+const META_POOL_DEPOSIT_NAME = `${META_POOL_NAME}Deposit`
+const TARGET_META_SWAP_DEPOSIT_NAME = `MetaSwapDeposit`
+const BASE_POOL_NAME = `SaddleBTCPoolV2`
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, get, getOrNull, log, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const metaPoolDeposit = await getOrNull(META_POOL_DEPOSIT_NAME)
+  if (metaPoolDeposit) {
+    log(`reusing ${META_POOL_DEPOSIT_NAME} at ${metaPoolDeposit.address}`)
+  } else {
+    const receipt = await execute(
+      "SwapDeployer",
+      {
+        from: deployer,
+        log: true,
+      },
+      "clone",
+      (
+        await get(TARGET_META_SWAP_DEPOSIT_NAME)
+      ).address,
+    )
+
+    const newPoolEvent = receipt?.events?.find(
+      (e: any) => e["event"] === "NewClone",
+    )
+    const deployedAddress = newPoolEvent["args"]["cloneAddress"]
+    log(
+      `deployed ${META_POOL_DEPOSIT_NAME} (targeting ${TARGET_META_SWAP_DEPOSIT_NAME}) at ${deployedAddress}`,
+    )
+    await save(META_POOL_DEPOSIT_NAME, {
+      abi: (await get(TARGET_META_SWAP_DEPOSIT_NAME)).abi,
+      address: deployedAddress,
+    })
+
+    await execute(
+      META_POOL_DEPOSIT_NAME,
+      { from: deployer, log: true, gasLimit: 1_000_000 },
+      "initialize",
+      (
+        await get(BASE_POOL_NAME)
+      ).address,
+      (
+        await get(META_POOL_NAME)
+      ).address,
+      (
+        await get(META_POOL_LP_TOKEN_NAME)
+      ).address,
+    )
+  }
+}
+export default func
+func.tags = [META_POOL_DEPOSIT_NAME]
+func.dependencies = ["TBTCMetaPoolTokens", META_POOL_NAME]

--- a/deploy/hardhat/464_deploy_CUSDMetaPoolV3.ts
+++ b/deploy/hardhat/464_deploy_CUSDMetaPoolV3.ts
@@ -1,0 +1,80 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+// Deployment names
+const META_POOL_NAME = "SaddleWCUSDMetaPoolV3"
+const META_POOL_LP_TOKEN_NAME = `${META_POOL_NAME}LPToken`
+const BASE_POOL_NAME = "SaddleUSDPoolV2"
+
+// Constructor arguments
+const TOKEN_NAMES = ["WCUSD", `${BASE_POOL_NAME}LPToken`]
+const TOKEN_DECIMALS = [18, 18]
+const LP_TOKEN_NAME = "Saddle wCUSD/saddleUSD-V2 V3 LP Token"
+const LP_TOKEN_SYMBOL = "saddleWCUSD-V3"
+const INITIAL_A = 100
+const SWAP_FEE = 4e6 // 4bps
+const ADMIN_FEE = 50e8
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, get, getOrNull, log, read, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const metaPool = await getOrNull(META_POOL_NAME)
+  if (metaPool) {
+    log(`reusing ${META_POOL_NAME} at ${metaPool.address}`)
+  } else {
+    const TOKEN_ADDRESSES = await Promise.all(
+      TOKEN_NAMES.map(async (name) => (await get(name)).address),
+    )
+
+    const receipt = await execute(
+      "SwapDeployer",
+      {
+        from: deployer,
+        log: true,
+      },
+      "deployMetaSwap",
+      (
+        await get("MetaSwapV3")
+      ).address,
+      TOKEN_ADDRESSES,
+      TOKEN_DECIMALS,
+      LP_TOKEN_NAME,
+      LP_TOKEN_SYMBOL,
+      INITIAL_A,
+      SWAP_FEE,
+      ADMIN_FEE,
+      (
+        await get("LPToken")
+      ).address,
+      (
+        await get(BASE_POOL_NAME)
+      ).address,
+    )
+
+    const newPoolEvent = receipt?.events?.find(
+      (e: any) => e["event"] === "NewSwapPool",
+    )
+    const deployedAddress = newPoolEvent["args"]["swapAddress"]
+    log(
+      `deployed ${META_POOL_NAME} (targeting "MetaSwapV3") at ${deployedAddress}`,
+    )
+    await save(META_POOL_NAME, {
+      abi: (await get("MetaSwapV3")).abi,
+      address: deployedAddress,
+    })
+
+    const lpTokenAddress = (await read(META_POOL_NAME, "swapStorage")).lpToken
+    log(`deployed ${META_POOL_LP_TOKEN_NAME} at ${lpTokenAddress}`)
+
+    await save(META_POOL_LP_TOKEN_NAME, {
+      abi: (await get("LPToken")).abi, // LPToken ABI
+      address: lpTokenAddress,
+    })
+  }
+}
+export default func
+func.tags = [META_POOL_NAME]
+func.dependencies = ["LPToken", "WCUSDMetaPoolTokens", "USDPoolV2"]

--- a/deploy/hardhat/465_deploy_CUSDMetaPoolV3Deposit.ts
+++ b/deploy/hardhat/465_deploy_CUSDMetaPoolV3Deposit.ts
@@ -1,0 +1,63 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+// Deployment names
+const META_POOL_NAME = "SaddleWCUSDMetaPoolV3"
+const META_POOL_LP_TOKEN_NAME = `${META_POOL_NAME}LPToken`
+const META_POOL_DEPOSIT_NAME = `${META_POOL_NAME}Deposit`
+const TARGET_META_SWAP_DEPOSIT_NAME = `MetaSwapDeposit`
+const BASE_POOL_NAME = `SaddleUSDPoolV2`
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, get, getOrNull, log, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const metaPoolDeposit = await getOrNull(META_POOL_DEPOSIT_NAME)
+  if (metaPoolDeposit) {
+    log(`reusing ${META_POOL_DEPOSIT_NAME} at ${metaPoolDeposit.address}`)
+  } else {
+    const receipt = await execute(
+      "SwapDeployer",
+      {
+        from: deployer,
+        log: true,
+      },
+      "clone",
+      (
+        await get(TARGET_META_SWAP_DEPOSIT_NAME)
+      ).address,
+    )
+
+    const newPoolEvent = receipt?.events?.find(
+      (e: any) => e["event"] === "NewClone",
+    )
+    const deployedAddress = newPoolEvent["args"]["cloneAddress"]
+    log(
+      `deployed ${META_POOL_DEPOSIT_NAME} (targeting ${TARGET_META_SWAP_DEPOSIT_NAME}) at ${deployedAddress}`,
+    )
+    await save(META_POOL_DEPOSIT_NAME, {
+      abi: (await get(TARGET_META_SWAP_DEPOSIT_NAME)).abi,
+      address: deployedAddress,
+    })
+
+    await execute(
+      META_POOL_DEPOSIT_NAME,
+      { from: deployer, log: true, gasLimit: 1_000_000 },
+      "initialize",
+      (
+        await get(BASE_POOL_NAME)
+      ).address,
+      (
+        await get(META_POOL_NAME)
+      ).address,
+      (
+        await get(META_POOL_LP_TOKEN_NAME)
+      ).address,
+    )
+  }
+}
+export default func
+func.tags = [META_POOL_DEPOSIT_NAME]
+func.dependencies = ["WCUSDMetaPoolTokens", META_POOL_NAME]

--- a/deploy/hardhat/466_register_new_pools.ts
+++ b/deploy/hardhat/466_register_new_pools.ts
@@ -1,0 +1,77 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { PoolRegistry } from "../../build/typechain"
+import { PoolType } from "../../utils/constants"
+import { IPoolRegistry } from "../../build/typechain/"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, ethers } = hre
+  const { get, execute, log } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const poolRegistry: PoolRegistry = await ethers.getContract("PoolRegistry")
+
+  const pools: IPoolRegistry.PoolInputDataStruct[] = [
+    {
+      // sUSD meta pool v3
+      poolAddress: (await get("SaddleSUSDMetaPoolV3")).address,
+      typeOfAsset: PoolType.USD,
+      poolName: ethers.utils.formatBytes32String("sUSD-USDv2_v3"),
+      targetAddress: (await get("MetaSwapV3")).address,
+      metaSwapDepositAddress: (await get("SaddleSUSDMetaPoolV3Deposit"))
+        .address,
+      isSaddleApproved: true,
+      isRemoved: false,
+      isGuarded: false,
+    },
+    {
+      // tBTCv2 meta pool v3
+      poolAddress: (await get("SaddleTBTCMetaPoolV3")).address,
+      typeOfAsset: PoolType.BTC,
+      poolName: ethers.utils.formatBytes32String("tBTCv2-BTCv2_v3"),
+      targetAddress: (await get("MetaSwapV3")).address,
+      metaSwapDepositAddress: (await get("SaddleTBTCMetaPoolV3Deposit"))
+        .address,
+      isSaddleApproved: true,
+      isRemoved: false,
+      isGuarded: false,
+    },
+    {
+      // WCUSD meta pool v3
+      poolAddress: (await get("SaddleWCUSDMetaPoolV3")).address,
+      typeOfAsset: PoolType.USD,
+      poolName: ethers.utils.formatBytes32String("WCUSD-USDv2_v3"),
+      targetAddress: (await get("MetaSwapV3")).address,
+      metaSwapDepositAddress: (await get("SaddleWCUSDMetaPoolV3Deposit"))
+        .address,
+      isSaddleApproved: true,
+      isRemoved: false,
+      isGuarded: false,
+    },
+  ]
+
+  await poolRegistry
+    .getPoolDataByName(pools[0].poolName)
+    .then(() => {
+      log("Skipping adding pools to registry because they are already added")
+    })
+    .catch(async () => {
+      log("Adding pools to registry")
+
+      const batchCall = await Promise.all(
+        pools.map(
+          async (pool) => await poolRegistry.populateTransaction.addPool(pool),
+        ),
+      )
+      const batchCallData = batchCall.map((x) => x.data).filter(Boolean)
+
+      await execute(
+        "PoolRegistry",
+        { from: deployer, log: true },
+        "batch",
+        batchCallData,
+        true,
+      )
+    })
+}
+export default func

--- a/deploy/hardhat/467_add_to_GeneralizedSwapMigrator.ts
+++ b/deploy/hardhat/467_add_to_GeneralizedSwapMigrator.ts
@@ -1,0 +1,93 @@
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { CHAIN_ID } from "../../utils/network"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId, ethers } = hre
+  const { execute, deploy, get, getOrNull, log, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  if ((await getChainId()) === CHAIN_ID.MAINNET) {
+    log("Cannot add to migrator on mainnet. Need to be executed by a multisig.")
+    return
+  }
+
+  // Check if migrator exists
+  await get("GeneralizedSwapMigrator")
+  const contract = await ethers.getContract("GeneralizedSwapMigrator")
+
+  const batchCall = [
+    await contract.populateTransaction.addMigrationData(
+      (
+        await get("SaddleSUSDMetaPoolUpdated")
+      ).address,
+      {
+        newPoolAddress: (await get("SaddleSUSDMetaPoolV3")).address,
+        oldPoolLPTokenAddress: (
+          await get("SaddleSUSDMetaPoolUpdatedLPToken")
+        ).address,
+        newPoolLPTokenAddress: (
+          await get("SaddleSUSDMetaPoolV3LPToken")
+        ).address,
+        tokens: [
+          (await get("SUSD")).address,
+          (await get("SaddleUSDPoolV2LPToken")).address,
+        ],
+      },
+      false,
+    ),
+    await contract.populateTransaction.addMigrationData(
+      (
+        await get("SaddleTBTCMetaPoolUpdated")
+      ).address,
+      {
+        newPoolAddress: (await get("SaddleTBTCMetaPoolV3")).address,
+        oldPoolLPTokenAddress: (
+          await get("SaddleTBTCMetaPoolUpdatedLPToken")
+        ).address,
+        newPoolLPTokenAddress: (
+          await get("SaddleTBTCMetaPoolV3LPToken")
+        ).address,
+        tokens: [
+          (await get("TBTCv2")).address,
+          (await get("SaddleBTCPoolV2LPToken")).address,
+        ],
+      },
+      false,
+    ),
+    await contract.populateTransaction.addMigrationData(
+      (
+        await get("SaddleWCUSDMetaPoolUpdated")
+      ).address,
+      {
+        newPoolAddress: (await get("SaddleWCUSDMetaPoolV3")).address,
+        oldPoolLPTokenAddress: (
+          await get("SaddleWCUSDMetaPoolUpdatedLPToken")
+        ).address,
+        newPoolLPTokenAddress: (
+          await get("SaddleWCUSDMetaPoolV3LPToken")
+        ).address,
+        tokens: [
+          (await get("WCUSD")).address,
+          (await get("SaddleUSDPoolV2LPToken")).address,
+        ],
+      },
+      false,
+    ),
+  ]
+
+  const batchCallData = batchCall.map((x) => x.data).filter(Boolean)
+
+  await execute(
+    "GeneralizedSwapMigrator",
+    {
+      from: deployer,
+      log: true,
+    },
+    "batch",
+    batchCallData,
+    true,
+  )
+}
+export default func
+func.tags = ["GeneralizedSwapMigrator"]

--- a/deploy/hardhat/470_check_4poolTokens.ts
+++ b/deploy/hardhat/470_check_4poolTokens.ts
@@ -1,0 +1,45 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { isTestNetwork } from "../../utils/network"
+import { BigNumber } from "ethers"
+
+const USD_TOKENS_ARGS: { [token: string]: any[] } = {
+  DAI: ["Dai Stablecoin", "DAI", "18"],
+  USDC: ["USD Coin", "USDC", "6"],
+  USDT: ["Tether USD", "USDT", "6"],
+  FRAX: ["Frax", "FRAX", "18"],
+}
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, execute, getOrNull, log } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  for (const token in USD_TOKENS_ARGS) {
+    const token_contracts = await getOrNull(token)
+    if (!token_contracts) {
+      await deploy(token, {
+        from: deployer,
+        log: true,
+        contract: "GenericERC20",
+        args: USD_TOKENS_ARGS[token],
+        skipIfAlreadyDeployed: true,
+      })
+      // If it's on hardhat, mint test tokens
+      if (isTestNetwork(await getChainId())) {
+        const decimals = USD_TOKENS_ARGS[token][2]
+        await execute(
+          token,
+          { from: deployer, log: true },
+          "mint",
+          deployer,
+          BigNumber.from(10).pow(decimals).mul(1000000),
+        )
+      }
+    } else {
+      log(`reusing ${token} at ${token_contracts.address}`)
+    }
+  }
+}
+export default func
+func.tags = ["4poolTokens"]

--- a/deploy/hardhat/471_deploy_4pool.ts
+++ b/deploy/hardhat/471_deploy_4pool.ts
@@ -1,0 +1,78 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+// Deployment Names
+const BASE_POOL_NAME = "Saddle4Pool"
+const BASE_POOL_LP_TOKEN_NAME = `${BASE_POOL_NAME}LPToken`
+
+// Constructor arguments
+const TOKEN_NAMES = ["DAI", "USDC", "USDT", "FRAX"]
+const TOKEN_DECIMALS = [18, 6, 6, 18]
+const LP_TOKEN_NAME = "Saddle DAI/USDC/USDT/FRAX LP Token"
+const LP_TOKEN_SYMBOL = "saddle4pool"
+const INITIAL_A = 500
+const SWAP_FEE = 3e6 // 3bps
+const ADMIN_FEE = 5e9 // 50% of the 3bps
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, get, getOrNull, log, read, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const saddle4pool = await getOrNull(BASE_POOL_NAME)
+  if (saddle4pool) {
+    log(`reusing ${BASE_POOL_NAME} Tokens at ${saddle4pool.address}`)
+  } else {
+    const TOKEN_ADDRESSES = await Promise.all(
+      TOKEN_NAMES.map(async (name) => (await get(name)).address),
+    )
+
+    const receipt = await execute(
+      "SwapDeployer",
+      { from: deployer, log: true },
+      "deploy",
+      (
+        await get("SwapFlashLoan")
+      ).address,
+      TOKEN_ADDRESSES,
+      TOKEN_DECIMALS,
+      LP_TOKEN_NAME,
+      LP_TOKEN_SYMBOL,
+      INITIAL_A,
+      SWAP_FEE,
+      ADMIN_FEE,
+      (
+        await get("LPToken")
+      ).address,
+    )
+
+    const newPoolEvent = receipt?.events?.find(
+      (e: any) => e["event"] == "NewSwapPool",
+    )
+    const deployedAddress = newPoolEvent["args"]["swapAddress"]
+    log(
+      `deployed ${BASE_POOL_NAME} (targeting "SwapFlashLoan") at ${deployedAddress}`,
+    )
+    await save(BASE_POOL_NAME, {
+      abi: (await get("SwapFlashLoan")).abi,
+      address: deployedAddress,
+    })
+
+    const lpTokenAddress = (await read(BASE_POOL_NAME, "swapStorage")).lpToken
+    log(`${LP_TOKEN_NAME} at ${lpTokenAddress}`)
+
+    await save(BASE_POOL_LP_TOKEN_NAME, {
+      abi: (await get("LPToken")).abi, // LPToken ABI
+      address: lpTokenAddress,
+    })
+  }
+}
+export default func
+func.tags = [BASE_POOL_NAME]
+func.dependencies = [
+  "SwapUtils",
+  "SwapFlashLoan",
+  "SwapDeployer",
+  "4poolTokens",
+]

--- a/deploy/hardhat/480_check_frax3poolTokens.ts
+++ b/deploy/hardhat/480_check_frax3poolTokens.ts
@@ -1,0 +1,44 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { isTestNetwork } from "../../utils/network"
+import { BigNumber } from "ethers"
+
+const USD_TOKENS_ARGS: { [token: string]: any[] } = {
+  USDC: ["USD Coin", "USDC", "6"],
+  USDT: ["Tether USD", "USDT", "6"],
+  FRAX: ["Frax", "FRAX", "18"],
+}
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, execute, getOrNull, log } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  for (const token in USD_TOKENS_ARGS) {
+    const token_contracts = await getOrNull(token)
+    if (!token_contracts) {
+      await deploy(token, {
+        from: deployer,
+        log: true,
+        contract: "GenericERC20",
+        args: USD_TOKENS_ARGS[token],
+        skipIfAlreadyDeployed: true,
+      })
+      // If it's on hardhat, mint test tokens
+      if (isTestNetwork(await getChainId())) {
+        const decimals = USD_TOKENS_ARGS[token][2]
+        await execute(
+          token,
+          { from: deployer, log: true },
+          "mint",
+          deployer,
+          BigNumber.from(10).pow(decimals).mul(1000000),
+        )
+      }
+    } else {
+      log(`reusing ${token} at ${token_contracts.address}`)
+    }
+  }
+}
+export default func
+func.tags = ["frax3poolTokens"]

--- a/deploy/hardhat/481_deploy_frax3pool.ts
+++ b/deploy/hardhat/481_deploy_frax3pool.ts
@@ -1,0 +1,78 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+// Deployment Names
+const BASE_POOL_NAME = "SaddleFrax3Pool"
+const BASE_POOL_LP_TOKEN_NAME = `${BASE_POOL_NAME}LPToken`
+
+// Constructor arguments
+const TOKEN_NAMES = ["USDC", "USDT", "FRAX"]
+const TOKEN_DECIMALS = [6, 6, 18]
+const LP_TOKEN_NAME = "Saddle USDC/USDT/FRAX LP Token"
+const LP_TOKEN_SYMBOL = "saddleUSDCUSDTFrax"
+const INITIAL_A = 500
+const SWAP_FEE = 4e6 // 4bps
+const ADMIN_FEE = 5e9 // 50% of the 3bps
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, get, getOrNull, log, read, save } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // Manually check if the pool is already deployed
+  const poolContract = await getOrNull(BASE_POOL_NAME)
+  if (poolContract) {
+    log(`reusing ${BASE_POOL_NAME} at ${poolContract.address}`)
+  } else {
+    const TOKEN_ADDRESSES = await Promise.all(
+      TOKEN_NAMES.map(async (name) => (await get(name)).address),
+    )
+
+    const receipt = await execute(
+      "SwapDeployer",
+      { from: deployer, log: true },
+      "deploy",
+      (
+        await get("SwapFlashLoan")
+      ).address,
+      TOKEN_ADDRESSES,
+      TOKEN_DECIMALS,
+      LP_TOKEN_NAME,
+      LP_TOKEN_SYMBOL,
+      INITIAL_A,
+      SWAP_FEE,
+      ADMIN_FEE,
+      (
+        await get("LPToken")
+      ).address,
+    )
+
+    const newPoolEvent = receipt?.events?.find(
+      (e: any) => e["event"] == "NewSwapPool",
+    )
+    const deployedAddress = newPoolEvent["args"]["swapAddress"]
+    log(
+      `deployed ${BASE_POOL_NAME} (targeting "SwapFlashLoan") at ${deployedAddress}`,
+    )
+    await save(BASE_POOL_NAME, {
+      abi: (await get("SwapFlashLoan")).abi,
+      address: deployedAddress,
+    })
+
+    const lpTokenAddress = (await read(BASE_POOL_NAME, "swapStorage")).lpToken
+    log(`${LP_TOKEN_NAME} at ${lpTokenAddress}`)
+
+    await save(BASE_POOL_LP_TOKEN_NAME, {
+      abi: (await get("LPToken")).abi, // LPToken ABI
+      address: lpTokenAddress,
+    })
+  }
+}
+export default func
+func.tags = [BASE_POOL_NAME]
+func.dependencies = [
+  "SwapUtils",
+  "SwapFlashLoan",
+  "SwapDeployer",
+  "frax3poolTokens",
+]

--- a/deploy/hardhat/482_register_new_pools.ts
+++ b/deploy/hardhat/482_register_new_pools.ts
@@ -1,0 +1,68 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { PoolRegistry } from "../../build/typechain"
+import { PoolType } from "../../utils/constants"
+import { IPoolRegistry } from "../../build/typechain"
+import { ZERO_ADDRESS } from "../../test/testUtils"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, ethers } = hre
+  const { get, execute, log } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const poolRegistry: PoolRegistry = await ethers.getContract("PoolRegistry")
+
+  const pools: IPoolRegistry.PoolInputDataStruct[] = [
+    {
+      // 4 pool will not be used on the frontend
+      poolAddress: (await get("Saddle4Pool")).address,
+      typeOfAsset: PoolType.USD,
+      poolName: ethers.utils.formatBytes32String("4pool"),
+      targetAddress: (await get("SwapFlashLoan")).address,
+      metaSwapDepositAddress: ZERO_ADDRESS,
+      isSaddleApproved: true,
+      isRemoved: true, // Mark as removed since this pool will not be featued
+      isGuarded: false,
+    },
+    {
+      // frax 3 pool that will featured on the frontend
+      poolAddress: (await get("SaddleFrax3Pool")).address,
+      typeOfAsset: PoolType.USD,
+      poolName: ethers.utils.formatBytes32String("frax3pool"),
+      targetAddress: (await get("SwapFlashLoan")).address,
+      metaSwapDepositAddress: ZERO_ADDRESS,
+      isSaddleApproved: true,
+      isRemoved: false,
+      isGuarded: false,
+    },
+  ]
+
+  await poolRegistry
+    .getPoolDataByName(pools[0].poolName)
+    .then(() => {
+      log("Skipping adding pools to registry because they are already added")
+    })
+    .catch(async () => {
+      log(
+        `Adding pools: [${pools.map((pool) =>
+          ethers.utils.parseBytes32String(pool.poolName),
+        )}] to registry`,
+      )
+
+      const batchCall = await Promise.all(
+        pools.map(
+          async (pool) => await poolRegistry.populateTransaction.addPool(pool),
+        ),
+      )
+      const batchCallData = batchCall.map((x) => x.data).filter(Boolean)
+
+      await execute(
+        "PoolRegistry",
+        { from: deployer, log: true },
+        "batch",
+        batchCallData,
+        true,
+      )
+    })
+}
+export default func

--- a/deploy/hardhat/492_deploy_SimpleRewarder.ts
+++ b/deploy/hardhat/492_deploy_SimpleRewarder.ts
@@ -1,0 +1,66 @@
+import { expect } from "chai"
+import { BigNumber } from "ethers"
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { CHAIN_ID } from "../../utils/network"
+
+const LP_TOKEN_CONTRACT_NAME = "SaddleTBTCMetaPoolV3LPToken"
+const REWARD_TOKEN_CONTRACT_NAME = "T"
+const SIMPLE_REWARDER_CONTRACT_NAME = "SimpleRewarder"
+const MINICHEFV2_CONTRACT_NAME = "MiniChefV2"
+const NEW_SIMPLE_REWARDER_CONTRACT_NAME = `${SIMPLE_REWARDER_CONTRACT_NAME}_${REWARD_TOKEN_CONTRACT_NAME}_${LP_TOKEN_CONTRACT_NAME}`
+
+const T_TEAM_MULTISIG_ADDRESS = "0xb78c0cf4c9e9bf4ba24b17065fa8c0ac71957653"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId, ethers } = hre
+  const { deploy, execute, get, getOrNull, save, read, log } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  if ((await getChainId()) === CHAIN_ID.HARDHAT) {
+    log(
+      `Running on hardhat. Skipping deploy of ${NEW_SIMPLE_REWARDER_CONTRACT_NAME}`,
+    )
+    return
+  }
+
+  if (!(await getOrNull(NEW_SIMPLE_REWARDER_CONTRACT_NAME))) {
+    await deploy(NEW_SIMPLE_REWARDER_CONTRACT_NAME, {
+      from: deployer,
+      log: true,
+      contract: SIMPLE_REWARDER_CONTRACT_NAME,
+      args: [(await get(MINICHEFV2_CONTRACT_NAME)).address],
+      skipIfAlreadyDeployed: true,
+    })
+
+    const PID = 8
+    const lpToken = (await get(LP_TOKEN_CONTRACT_NAME)).address
+    const rewardToken = (await get(REWARD_TOKEN_CONTRACT_NAME)).address // T token
+    const rewardAdmin = T_TEAM_MULTISIG_ADDRESS // T team's OpEx wallet
+    const rewardPerSecond = BigNumber.from("0") // Let T team handle the rate
+
+    // Ensure pid is correct
+    expect(await read(MINICHEFV2_CONTRACT_NAME, "lpToken", PID)).to.eq(lpToken)
+
+    // (IERC20 rewardToken, address owner, uint256 rewardPerSecond, IERC20 masterLpToken, uint256 pid)
+    const data = ethers.utils.defaultAbiCoder.encode(
+      ["address", "address", "uint256", "address", "uint256"],
+      [
+        rewardToken, // KEEP token
+        rewardAdmin, // KEEP team's OpEx wallet
+        rewardPerSecond, // 250k KEEP weekly
+        lpToken, // master LP token
+        PID, // pid
+      ],
+    )
+
+    await execute(
+      NEW_SIMPLE_REWARDER_CONTRACT_NAME,
+      { from: deployer, log: true },
+      "init",
+      data,
+    )
+  }
+}
+func.skip = async (env) => false
+export default func

--- a/deploy/hardhat/990_transfer_ownership.ts
+++ b/deploy/hardhat/990_transfer_ownership.ts
@@ -1,0 +1,56 @@
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { MULTISIG_ADDRESSES } from "../../utils/accounts"
+import { isMainnet } from "../../utils/network"
+import path from "path"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { execute, log, read } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const contractsToTransferOwnership = [
+    "Allowlist",
+    "SaddleBTCPool",
+    "SaddleUSDPool",
+    "SaddleVETH2Pool",
+    "SaddleALETHPool",
+    "SaddleD4Pool",
+  ]
+
+  const currentChain = await getChainId()
+  if (isMainnet(currentChain)) {
+    for (const contract of contractsToTransferOwnership) {
+      // Check current owner
+      const currentOwner = await read(contract, "owner")
+
+      // If the deployer still owns the contract, then transfer the ownership to the multisig
+      if (currentOwner == deployer) {
+        log(
+          `transferring the ownership of "${contract}" to the multisig: ${MULTISIG_ADDRESSES[currentChain]}`,
+        )
+        await execute(
+          contract,
+          { from: deployer, log: true },
+          "transferOwnership",
+          MULTISIG_ADDRESSES[currentChain],
+        )
+      }
+      // If Multisig already owns the contract, skip
+      else if (currentOwner == MULTISIG_ADDRESSES[currentChain]) {
+        log(
+          `"${contract}" is already owned by the multisig: ${MULTISIG_ADDRESSES[currentChain]}`,
+        )
+      }
+      // Someone else owns the contract
+      else {
+        log(`"${contract}" is owned by unrecognized address: ${currentOwner}`)
+      }
+    }
+  } else {
+    log(`deployment is not on mainnet. skipping ${path.basename(__filename)}`)
+  }
+}
+export default func
+func.tags = ["TransferOwnership"]
+func.dependencies = ["Allowlist", "BTCPool", "USDPool"]

--- a/deploy/hardhat/999_impersonate_owners.ts
+++ b/deploy/hardhat/999_impersonate_owners.ts
@@ -1,0 +1,81 @@
+import {
+  asyncForEach,
+  impersonateAccount,
+  setEtherBalance,
+} from "../../test/testUtils"
+
+import { DeployFunction } from "hardhat-deploy/types"
+import { GenericERC20 } from "../../build/typechain/"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import dotenv from "dotenv"
+import { ethers } from "hardhat"
+import { isMainnet } from "../../utils/network"
+import path from "path"
+
+dotenv.config()
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { execute, log, read, all, get } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  // These addresses are for large holders of the given token (used in forked mainnet testing)
+  // You can find whales' addresses on etherscan's holders page.
+  // Example: https://etherscan.io/token/0x6b175474e89094c44da98b954eedeac495271d0f#balances
+  // Note that some addresses may be blacklisted so if the top address didnt work, try another instead.
+  // key = token deployment name, value = array of addresses
+  const tokenToAccountsMap: Record<string, string[]> = {
+    // USD
+    DAI: ["0xa5407eae9ba41422680e2e00537571bcc53efbfd"],
+    USDC: ["0xa5407eae9ba41422680e2e00537571bcc53efbfd"],
+    USDT: ["0xa5407eae9ba41422680e2e00537571bcc53efbfd"],
+    SUSD: ["0xa5407eae9ba41422680e2e00537571bcc53efbfd"],
+    // BTC
+    WBTC: ["0x7fc77b5c7614e1533320ea6ddc2eb61fa00a9714"],
+    RENBTC: ["0x7fc77b5c7614e1533320ea6ddc2eb61fa00a9714"],
+    SBTC: ["0x7fc77b5c7614e1533320ea6ddc2eb61fa00a9714"],
+    TBTC: ["0xC25099792E9349C7DD09759744ea681C7de2cb66"],
+    // ETH
+    ALETH: ["0x1d2c4cd9bee9dfe088430b95d274e765151c32db"],
+    WETH: ["0xceff51756c56ceffca006cd410b03ffc46dd3a58"],
+    SETH: ["0xc5424b857f758e906013f3555dad202e4bdb4567"],
+    // D4
+    ALUSD: ["0x43b4fdfd4ff969587185cdb6f0bd875c5fc83f8c"],
+    FEI: ["0x94b0a3d511b6ecdb17ebf877278ab030acb0a878"],
+    FRAX: ["0xd632f22692fac7611d2aa1c0d552930d43caed3b"],
+    LUSD: ["0x66017d22b0f8556afdd19fc67041899eb65a21bb"],
+    // TBTC
+    TBTCv2: ["0xf9e11762d522ea29dd78178c9baf83b7b093aacc"],
+  }
+
+  if (
+    isMainnet(await getChainId()) &&
+    process.env.FORK_NETWORK &&
+    process.env.FUND_FORK_NETWORK
+  ) {
+    // Give the deployer tokens from each token holder for testing
+    for (const [tokenName, holders] of Object.entries(tokenToAccountsMap)) {
+      const contract = (await ethers.getContract(tokenName)) as GenericERC20
+
+      await asyncForEach(holders, async (holder) => {
+        const balance = await contract.balanceOf(holder)
+        await setEtherBalance(holder, 1e20)
+        await contract
+          .connect(await impersonateAccount(holder))
+          .transfer(deployer, await contract.balanceOf(holder))
+        log(
+          `Sent ${ethers.utils.formatUnits(
+            balance,
+            await contract.decimals(),
+          )} ${tokenName} from ${holder} to ${deployer}`,
+        )
+      })
+    }
+    // Give the deployer some ether to use for testing
+    await setEtherBalance(deployer, 1e20)
+  } else {
+    log(`skipping ${path.basename(__filename)}`)
+  }
+}
+
+export default func

--- a/deploy/hardhat/999_print_addresses.ts
+++ b/deploy/hardhat/999_print_addresses.ts
@@ -1,0 +1,19 @@
+import { DeployFunction } from "hardhat-deploy/types"
+import { Deployment } from "hardhat-deploy/dist/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { execute, log, read, all } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const allContracts: { [p: string]: Deployment } = await all()
+
+  const arr = []
+  console.table(
+    Object.keys(allContracts).map((k) => [k, allContracts[k].address]),
+  )
+}
+export default func
+func.tags = ["TransferOwnership"]
+func.dependencies = ["Allowlist", "BTCPool", "USDPool"]

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -26,7 +26,7 @@ let config: HardhatUserConfig = {
   defaultNetwork: "hardhat",
   networks: {
     hardhat: {
-      deploy: ["./deploy/mainnet/"],
+      deploy: ["./deploy/hardhat/"],
       autoImpersonate: true,
     },
     mainnet: {


### PR DESCRIPTION
- This is to make managing deploy scripts easier per network
- All scripts in `deploy/hardhat` are copied from `deploy/mainnet`