### PR TITLE
Add 'working_balance' logging to setup script

### DIFF
--- a/scripts/prepareForFirstWeekLaunch.ts
+++ b/scripts/prepareForFirstWeekLaunch.ts
@@ -262,12 +262,21 @@ async function main() {
     `Total supply of ${USD_V2_GAUGE_NAME}: `,
     (await usdv2Gauge.totalSupply()).toString(),
   )
+  console.log(
+    `Working supply of ${USD_V2_GAUGE_NAME}: `,
+    (await usdv2Gauge.working_supply()).toString(),
+  )
+
   await usdv2Gauge.connect(signers[1])["deposit(uint256)"](BIG_NUMBER_1E18)
   // Deposit into gauge from un-boosted account
   await usdv2Gauge.connect(signers[2])["deposit(uint256)"](BIG_NUMBER_1E18)
   console.log(
     `Total supply of ${USD_V2_GAUGE_NAME} after deposits: `,
     (await usdv2Gauge.totalSupply()).toString(),
+  )
+  console.log(
+    `Working supply of ${USD_V2_GAUGE_NAME}: `,
+    (await usdv2Gauge.working_supply()).toString(),
   )
 }
 

--- a/scripts/prepareForSecondWeekLaunch.ts
+++ b/scripts/prepareForSecondWeekLaunch.ts
@@ -36,9 +36,12 @@ async function main() {
   const signers = await ethers.getSigners()
 
   const WEEK = 86400 * 7
+
+
   const gaugeHelperContract = (await ethers.getContract(
     "GaugeHelperContract",
   )) as GaugeHelperContract
+
 
   // You can freely modify timestamps and the state of the contracts to your liking.
   // For how you want to set up the contracts, please refer to test files in test/tokenomics
@@ -152,6 +155,17 @@ async function main() {
     )
   }
 
+  // Log working balances for signers[1] and signers[2] in usdV2Gauge
+  for (let i = 1; i < 3; i++) {
+    const signer = signers[i]
+    const workingBalance = await usdV2Gauge.working_balances(
+      signer.address
+    )
+    console.log(
+      `${USD_V2_GAUGE_NAME} Working balance for signer[${i}] ${signer.address}: ${workingBalance}`,
+    )
+  }
+
   // advance timestamp 1 week
   console.log("timestamp: ", await getCurrentBlockTimestamp())
   await increaseTimestamp(WEEK)
@@ -166,6 +180,28 @@ async function main() {
     )
     console.log(
       `${USD_V2_GAUGE_NAME} Claimable rewards for signer[${i}] ${signer.address}: ${claimableRewards}`,
+    )
+  }
+
+  // Call user_checkpoint() to update working_balances of signer[1] and signer[2]
+  for (let i = 1; i < 3; i++) {
+    const signer = signers[i]
+    await usdV2Gauge.user_checkpoint(
+      signer.address
+    )
+    console.log(
+      `${USD_V2_GAUGE_NAME} Called user_checkpoint for signer[${i}] ${signer.address}`,
+    )
+  }
+
+  // Log working balances for signers[1] and signers[2] in usdV2Gauge
+  for (let i = 1; i < 3; i++) {
+    const signer = signers[i]
+    const workingBalance = await usdV2Gauge.working_balances(
+      signer.address
+    )
+    console.log(
+      `${USD_V2_GAUGE_NAME} Working balance for signer[${i}] ${signer.address}: ${workingBalance}`,
     )
   }
 }

--- a/scripts/prepareForSecondWeekLaunch.ts
+++ b/scripts/prepareForSecondWeekLaunch.ts
@@ -186,10 +186,11 @@ async function main() {
   // Call user_checkpoint() to update working_balances of signer[1] and signer[2]
   for (let i = 1; i < 3; i++) {
     const signer = signers[i]
-    await usdV2Gauge.user_checkpoint(
-      signer.address,
-      { gasLimit: 3_000_000 }
-    )
+    await usdV2Gauge.
+      connect(signer).user_checkpoint(
+        signer.address,
+        { gasLimit: 3_000_000 }
+      )
     console.log(
       `${USD_V2_GAUGE_NAME} Called user_checkpoint for signer[${i}] ${signer.address}`,
     )

--- a/scripts/prepareForSecondWeekLaunch.ts
+++ b/scripts/prepareForSecondWeekLaunch.ts
@@ -187,7 +187,8 @@ async function main() {
   for (let i = 1; i < 3; i++) {
     const signer = signers[i]
     await usdV2Gauge.user_checkpoint(
-      signer.address
+      signer.address,
+      { gasLimit: 3_000_000 }
     )
     console.log(
       `${USD_V2_GAUGE_NAME} Called user_checkpoint for signer[${i}] ${signer.address}`,


### PR DESCRIPTION
- Calling `user_checkpoint()` after time jump to update 'working_balances', so boost calculator testing on front end works
- Added logging of `working_supply` and 'working_balances'
