### PR TITLE
Add tests for 'ChildChainStreamer'

### DIFF
--- a/test/tokenomics/rootGaugeLocal.ts
+++ b/test/tokenomics/rootGaugeLocal.ts
@@ -259,65 +259,100 @@ describe("Root Gauge (Local)", () => {
   describe("childChainStreamer", () => {
     beforeEach(async () => {
       // Increase time stamp by 12 hours, to be well into the current period
-      await setTimestamp(await getCurrentBlockTimestamp() + (DAY/2))
+      await setTimestamp((await getCurrentBlockTimestamp()) + DAY / 2)
 
-      console.log(`'Rewards received' before: ${(await childChainStreamer.reward_data(sdl.address))[4]}\n` +
-                  `'Last update time' before: ${await childChainStreamer.last_update_time()}`)
+      console.log(
+        `'Rewards received' before: ${
+          (await childChainStreamer.reward_data(sdl.address))[4]
+        }\n` +
+          `'Last update time' before: ${await childChainStreamer.last_update_time()}`,
+      )
     })
 
     afterEach(async () => {
-      console.log(`'Rewards received' after: ${(await childChainStreamer.reward_data(sdl.address))[4]}\n` +
-                  `'Last update time' after: ${await childChainStreamer.last_update_time()}\n\n`)
-    })
-
-    it(`Reverts when notified and no new rewards were deposited`, async () => {      
-      // Call notify_reward_amount from distributor within active period
-      await expect(childChainStreamer.connect(signers[10]).notify_reward_amount(sdl.address)).to.be.revertedWith(
-        "Invalid token or no new reward"
+      console.log(
+        `'Rewards received' after: ${
+          (await childChainStreamer.reward_data(sdl.address))[4]
+        }\n` +
+          `'Last update time' after: ${await childChainStreamer.last_update_time()}\n\n`,
       )
     })
-    
-    it(`Reverts when notified by non-distributor within active period`, async () => {      
-      // Simulate new SDL rewards coming from RootGauge 
-      await sdl.transfer(childChainStreamer.address, BIG_NUMBER_1E18.mul(500_000)) 
+
+    it(`Reverts when notified and no new rewards were deposited`, async () => {
+      // Call notify_reward_amount from distributor within active period
+      await expect(
+        childChainStreamer
+          .connect(signers[10])
+          .notify_reward_amount(sdl.address),
+      ).to.be.revertedWith("Invalid token or no new reward")
+    })
+
+    it(`Reverts when notified by non-distributor within active period`, async () => {
+      // Simulate new SDL rewards coming from RootGauge
+      await sdl.transfer(
+        childChainStreamer.address,
+        BIG_NUMBER_1E18.mul(500_000),
+      )
 
       // Call notify_reward_amount from non-distributor within active period
-      await expect(childChainStreamer.connect(signers[10]).notify_reward_amount(sdl.address)).to.be.revertedWith(
-        "Reward period still active"
-      )
+      await expect(
+        childChainStreamer
+          .connect(signers[10])
+          .notify_reward_amount(sdl.address),
+      ).to.be.revertedWith("Reward period still active")
     })
 
     it(`Succeeds when notified by distributor within active period`, async () => {
       const lastUpdateTime = await childChainStreamer.last_update_time()
-      const rewardsReceived = (await childChainStreamer.reward_data(sdl.address))[4]
+      const rewardsReceived = (
+        await childChainStreamer.reward_data(sdl.address)
+      )[4]
 
-      // Simulate new SDL rewards coming from RootGauge 
-      await sdl.transfer(childChainStreamer.address, BIG_NUMBER_1E18.mul(500_000))
+      // Simulate new SDL rewards coming from RootGauge
+      await sdl.transfer(
+        childChainStreamer.address,
+        BIG_NUMBER_1E18.mul(500_000),
+      )
 
       // Call notify_reward_amount from distributor (deployer)
-      await childChainStreamer.connect(deployer).notify_reward_amount(sdl.address)
+      await childChainStreamer
+        .connect(deployer)
+        .notify_reward_amount(sdl.address)
 
-      expect(await childChainStreamer.last_update_time()).to.be.gt(lastUpdateTime)
+      expect(await childChainStreamer.last_update_time()).to.be.gt(
+        lastUpdateTime,
+      )
       expect((await childChainStreamer.reward_data(sdl.address))[4]).to.be.eq(
-        rewardsReceived.add(BIG_NUMBER_1E18.mul(500_000)))
+        rewardsReceived.add(BIG_NUMBER_1E18.mul(500_000)),
+      )
     })
 
-    it(`Succeeds when notified by non-distributor after period ended`, async () => {     
+    it(`Succeeds when notified by non-distributor after period ended`, async () => {
       const lastUpdateTime = await childChainStreamer.last_update_time()
-      const rewardsReceived = (await childChainStreamer.reward_data(sdl.address))[4]
-      
+      const rewardsReceived = (
+        await childChainStreamer.reward_data(sdl.address)
+      )[4]
+
       // Increase time stamp by 1 week, so active period is over
-      await setTimestamp(await getCurrentBlockTimestamp() + (WEEK))
+      await setTimestamp((await getCurrentBlockTimestamp()) + WEEK)
 
-      // Simulate new SDL rewards coming from RootGauge 
-      await sdl.transfer(childChainStreamer.address, BIG_NUMBER_1E18.mul(500_000))
-      
+      // Simulate new SDL rewards coming from RootGauge
+      await sdl.transfer(
+        childChainStreamer.address,
+        BIG_NUMBER_1E18.mul(500_000),
+      )
+
       // Call notify_reward_amount from non-distributor outside active period
-      await childChainStreamer.connect(signers[10]).notify_reward_amount(sdl.address)
+      await childChainStreamer
+        .connect(signers[10])
+        .notify_reward_amount(sdl.address)
 
-      expect(await childChainStreamer.last_update_time()).to.be.gt(lastUpdateTime)
+      expect(await childChainStreamer.last_update_time()).to.be.gt(
+        lastUpdateTime,
+      )
       expect((await childChainStreamer.reward_data(sdl.address))[4]).to.be.eq(
-        rewardsReceived.add(BIG_NUMBER_1E18.mul(500_000)))
+        rewardsReceived.add(BIG_NUMBER_1E18.mul(500_000)),
+      )
     })
   })
 })

--- a/test/tokenomics/rootGaugeLocal.ts
+++ b/test/tokenomics/rootGaugeLocal.ts
@@ -255,4 +255,18 @@ describe("Root Gauge (Local)", () => {
       expect(await rootGauge.name()).to.eq(expectedName)
     })
   })
+
+  describe("childChainStreamer", () => {
+    it(`Reverts when notified by non-distributor within active period`, async () => {
+      // TODO: fill in test
+    })
+
+    it(`Succeeds when notified by distributor within active period`, async () => {
+      // TODO: fill in test
+    })
+
+    it(`Succeeds when notified by non-distributor after period ended`, async () => {
+      // TODO: fill in test
+    })
+  })
 })

--- a/test/tokenomics/rootGaugeLocal.ts
+++ b/test/tokenomics/rootGaugeLocal.ts
@@ -259,7 +259,7 @@ describe("Root Gauge (Local)", () => {
   describe("childChainStreamer", () => {
     beforeEach(async () => {
       // Increase time stamp by 12 hours, to be well into the current period
-      await increaseTimestamp(DAY/2)
+      await setTimestamp(await getCurrentBlockTimestamp() + (DAY/2))
 
       console.log(`'Rewards received' before: ${(await childChainStreamer.reward_data(sdl.address))[4]}\n` +
                   `'Last update time' before: ${await childChainStreamer.last_update_time()}`)
@@ -268,7 +268,6 @@ describe("Root Gauge (Local)", () => {
     afterEach(async () => {
       console.log(`'Rewards received' after: ${(await childChainStreamer.reward_data(sdl.address))[4]}\n` +
                   `'Last update time' after: ${await childChainStreamer.last_update_time()}\n\n`)
-                 
     })
 
     it(`Reverts when notified and no new rewards were deposited`, async () => {      
@@ -308,7 +307,7 @@ describe("Root Gauge (Local)", () => {
       const rewards_received = (await childChainStreamer.reward_data(sdl.address))[4]
       
       // Increase time stamp by 1 week, so active period is over
-      await increaseTimestamp(WEEK)
+      await setTimestamp(await getCurrentBlockTimestamp() + (WEEK))
 
       // Simulate new SDL rewards coming from RootGauge 
       await sdl.transfer(childChainStreamer.address, BIG_NUMBER_1E18.mul(500_000))

--- a/test/tokenomics/rootGaugeLocal.ts
+++ b/test/tokenomics/rootGaugeLocal.ts
@@ -288,8 +288,8 @@ describe("Root Gauge (Local)", () => {
     })
 
     it(`Succeeds when notified by distributor within active period`, async () => {
-      const last_update_time = await childChainStreamer.last_update_time()
-      const rewards_received = (await childChainStreamer.reward_data(sdl.address))[4]
+      const lastUpdateTime = await childChainStreamer.last_update_time()
+      const rewardsReceived = (await childChainStreamer.reward_data(sdl.address))[4]
 
       // Simulate new SDL rewards coming from RootGauge 
       await sdl.transfer(childChainStreamer.address, BIG_NUMBER_1E18.mul(500_000))
@@ -297,14 +297,14 @@ describe("Root Gauge (Local)", () => {
       // Call notify_reward_amount from distributor (deployer)
       await childChainStreamer.connect(deployer).notify_reward_amount(sdl.address)
 
-      await expect(await childChainStreamer.last_update_time()).to.be.gt(last_update_time)
-      await expect((await childChainStreamer.reward_data(sdl.address))[4]).to.be.eq(
-        rewards_received.add(BIG_NUMBER_1E18.mul(500_000)))
+      expect(await childChainStreamer.last_update_time()).to.be.gt(lastUpdateTime)
+      expect((await childChainStreamer.reward_data(sdl.address))[4]).to.be.eq(
+        rewardsReceived.add(BIG_NUMBER_1E18.mul(500_000)))
     })
 
     it(`Succeeds when notified by non-distributor after period ended`, async () => {     
-      const last_update_time = await childChainStreamer.last_update_time()
-      const rewards_received = (await childChainStreamer.reward_data(sdl.address))[4]
+      const lastUpdateTime = await childChainStreamer.last_update_time()
+      const rewardsReceived = (await childChainStreamer.reward_data(sdl.address))[4]
       
       // Increase time stamp by 1 week, so active period is over
       await setTimestamp(await getCurrentBlockTimestamp() + (WEEK))
@@ -315,9 +315,9 @@ describe("Root Gauge (Local)", () => {
       // Call notify_reward_amount from non-distributor outside active period
       await childChainStreamer.connect(signers[10]).notify_reward_amount(sdl.address)
 
-      await expect(await childChainStreamer.last_update_time()).to.be.gt(last_update_time)
-      await expect((await childChainStreamer.reward_data(sdl.address))[4]).to.be.eq(
-        rewards_received.add(BIG_NUMBER_1E18.mul(500_000)))
+      expect(await childChainStreamer.last_update_time()).to.be.gt(lastUpdateTime)
+      expect((await childChainStreamer.reward_data(sdl.address))[4]).to.be.eq(
+        rewardsReceived.add(BIG_NUMBER_1E18.mul(500_000)))
     })
   })
 })


### PR DESCRIPTION
Test cases:
- Reverts when notified and no new rewards were deposited
- Reverts when notified by non-distributor within active period
- Succeeds when notified by distributor within active period
- Succeeds when notified by non-distributor after period ended