### PR TITLE
Disable fallbackToGlobal on SimpleRewarder tests

### DIFF
--- a/test/rewards/simpleRewarder.ts
+++ b/test/rewards/simpleRewarder.ts
@@ -42,7 +42,9 @@ describe("SimpleRewarder", async () => {
 
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
-      await deployments.fixture(["USDPoolV2"])
+      await deployments.fixture(["USDPoolV2"], {
+        fallbackToGlobal: false,
+      })
       await setTimestamp(TEST_START_TIMESTAMP)
 
       signers = await ethers.getSigners()

--- a/test/rewards/simpleRewarderNotFilled.ts
+++ b/test/rewards/simpleRewarderNotFilled.ts
@@ -40,7 +40,9 @@ describe("SimpleRewarder with MiniChefv2 but with ", async () => {
 
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
-      await deployments.fixture(["USDPoolV2"])
+      await deployments.fixture(["USDPoolV2"], {
+        fallbackToGlobal: false,
+      })
       await setTimestamp(TEST_START_TIMESTAMP)
 
       signers = await ethers.getSigners()


### PR DESCRIPTION
* Forces SimpleRewarder tests to not use global fixture