### PR TITLE
Deploy SDL on Kovan for Optimism bridge integration

### DIFF
--- a/deploy/kovan/001_deploy_vesting.ts
+++ b/deploy/kovan/001_deploy_vesting.ts
@@ -1,0 +1,16 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  await deploy("Vesting", {
+    from: deployer,
+    log: true,
+    skipIfAlreadyDeployed: true,
+  })
+}
+export default func
+func.tags = ["Vesting"]

--- a/deploy/kovan/001_deploy_vesting.ts
+++ b/deploy/kovan/001_deploy_vesting.ts
@@ -6,6 +6,10 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deploy } = deployments
   const { deployer } = await getNamedAccounts()
 
+  // skipped due to lack of ETH on Kovan. 
+  // using vacuous address for vesting contract on SDL deployfor now
+  return
+
   await deploy("Vesting", {
     from: deployer,
     log: true,

--- a/deploy/kovan/002_deploy_SDL.ts
+++ b/deploy/kovan/002_deploy_SDL.ts
@@ -9,11 +9,21 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   const unlockPeriod = isTestNetwork(await getChainId()) ? 0 : 7890000 // 3 months in seconds
 
+  /*
   await deploy("SDL", {
     from: deployer,
     log: true,
     skipIfAlreadyDeployed: true,
     args: [deployer, unlockPeriod, (await get("Vesting")).address],
+  })
+  */
+
+  // using vacuous address for vesting contract
+  await deploy("SDL", {
+    from: deployer,
+    log: true,
+    skipIfAlreadyDeployed: true,
+    args: [deployer, unlockPeriod, "0x0000000000000000000000000000000000000001"],
   })
 }
 export default func

--- a/deploy/kovan/002_deploy_SDL.ts
+++ b/deploy/kovan/002_deploy_SDL.ts
@@ -1,0 +1,20 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { isTestNetwork } from "../../utils/network"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, get, execute, getOrNull } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const unlockPeriod = isTestNetwork(await getChainId()) ? 0 : 7890000 // 3 months in seconds
+
+  await deploy("SDL", {
+    from: deployer,
+    log: true,
+    skipIfAlreadyDeployed: true,
+    args: [deployer, unlockPeriod, (await get("Vesting")).address],
+  })
+}
+export default func
+func.tags = ["SDL"]

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -48,6 +48,7 @@ let config: HardhatUserConfig = {
     },
     kovan: {
       url: ALCHEMY_BASE_URL[CHAIN_ID.KOVAN] + process.env.ALCHEMY_API_KEY,
+      chainId: 42,
       accounts: {
         mnemonic: process.env.MNEMONIC_TEST_ACCOUNT,
       },
@@ -232,6 +233,7 @@ let config: HardhatUserConfig = {
       2221: 0, // use the same address on kava testnet
       2222: 0, // use the same address on kava testnet
       3: 0, // use the same address on ropsten
+      42: 0 // use the same address on kovan
     },
     libraryDeployer: {
       default: 1, // use a different account for deploying libraries on the hardhat network
@@ -244,6 +246,7 @@ let config: HardhatUserConfig = {
       2221: 0, // use the same address on kava testnet
       2222: 0, // use the same address on kava testnet
       3: 0, // use the same address on ropsten
+      42: 0 // use the same address on kovan
     },
     multisig: {
       default: 0,
@@ -284,6 +287,10 @@ if (process.env.ACCOUNT_PRIVATE_KEYS) {
     },
     kava_mainnet: {
       ...config.networks?.kava_mainnet,
+      accounts: JSON.parse(process.env.ACCOUNT_PRIVATE_KEYS),
+    },
+    kovan: {
+      ...config.networks?.kovan,
       accounts: JSON.parse(process.env.ACCOUNT_PRIVATE_KEYS),
     },
   }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -46,6 +46,13 @@ let config: HardhatUserConfig = {
       },
       deploy: ["./deploy/ropsten/"],
     },
+    kovan: {
+      url: ALCHEMY_BASE_URL[CHAIN_ID.KOVAN] + process.env.ALCHEMY_API_KEY,
+      accounts: {
+        mnemonic: process.env.MNEMONIC_TEST_ACCOUNT,
+      },
+      deploy: ["./deploy/kovan/"],
+    },
     arbitrum_testnet: {
       url:
         ALCHEMY_BASE_URL[CHAIN_ID.ARBITRUM_TESTNET] +

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -31,6 +31,12 @@ const DEPLOYMENTS_TO_NETWORK = {
     explorerApi: "https://api-ropsten.etherscan.io",
     apiKeyName: "ETHERSCAN_API",
   },
+  kovan: {
+    id: 42,
+    test: true,
+    explorerApi: "https://api-kovan.etherscan.io",
+    apiKeyName: "ETHERSCAN_API",
+  },
   localhost: { id: 31337, test: true },
 }
 

--- a/utils/network.ts
+++ b/utils/network.ts
@@ -46,6 +46,7 @@ export function isHardhatNetwork(networkId: string): boolean {
 export const ALCHEMY_BASE_URL = {
   [CHAIN_ID.MAINNET]: "https://eth-mainnet.alchemyapi.io/v2/",
   [CHAIN_ID.ROPSTEN]: "https://eth-ropsten.alchemyapi.io/v2/",
+  [CHAIN_ID.KOVAN]: "https://eth-kovan.alchemyapi.io/v2/",
   [CHAIN_ID.ARBITRUM_MAINNET]: "https://arb-mainnet.g.alchemy.com/v2/",
   [CHAIN_ID.ARBITRUM_TESTNET]: "https://arb-rinkeby.g.alchemy.com/v2/",
 }


### PR DESCRIPTION
- Optimism requires a representation of SDL on Kovan for them to test the token. This is part of the process of adding SDL to their "Standard Token List". Once it's integrated there, SDL will show up on the canonical Optimism bridge front end.

- See [here ](https://github.com/ethereum-optimism/ethereum-optimism.github.io#adding-a-token-to-the-list)for details