### PR TITLE
Deploy script for fake USDC

### DIFF
--- a/deploy/hardhat/640_deploy_fake_USDC.ts
+++ b/deploy/hardhat/640_deploy_fake_USDC.ts
@@ -1,0 +1,37 @@
+import { BigNumber } from "ethers"
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { isTestNetwork } from "../../utils/network"
+
+const TOKENS_ARGS: { [token: string]: any[] } = {
+  USDC_FAKE: ["USD coin", "USDC", "6"],
+}
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { deploy, execute } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  for (const token in TOKENS_ARGS) {
+    await deploy(token, {
+      from: deployer,
+      log: true,
+      contract: "GenericERC20",
+      args: TOKENS_ARGS[token],
+      skipIfAlreadyDeployed: true,
+    })
+    // If it's on hardhat, mint test tokens
+    if (isTestNetwork(await getChainId())) {
+      const decimals = TOKENS_ARGS[token][2]
+      await execute(
+        token,
+        { from: deployer, log: true },
+        "mint",
+        deployer,
+        BigNumber.from(10).pow(decimals).mul(1000000),
+      )
+    }
+  }
+}
+export default func
+func.tags = ["USDC_FAKE"]


### PR DESCRIPTION
Deploys a same token as USDC info for testing duplicate token.