### PR TITLE
Cleans up hardhat config file and moves tasks into tasks folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ npm run coverage
 ### Deploying contracts to localhost Hardhat EVM
 
 ```bash
-$ npm run start
+$ npx hardhat node
 ```
 You can connect to this RPC server via `http://localhost:8545` with chain ID of 31337
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -3,20 +3,15 @@ import "@nomiclabs/hardhat-vyper"
 import "hardhat-deploy"
 import "hardhat-spdx-license-identifier"
 
-import { HardhatUserConfig, task } from "hardhat/config"
 import dotenv from "dotenv"
+import { HardhatUserConfig } from "hardhat/config"
+import "./tasks"
+import { MULTISIG_ADDRESSES } from "./utils/accounts"
 import { ALCHEMY_BASE_URL, CHAIN_ID } from "./utils/network"
-import { MULTISIG_ADDRESSES, PROD_DEPLOYER_ADDRESS } from "./utils/accounts"
-import { Deployment } from "hardhat-deploy/dist/types"
-import { HttpNetworkUserConfig } from "hardhat/types"
 
 dotenv.config()
 
-if (process.env.HARDHAT_FORK) {
-  process.env["HARDHAT_DEPLOY_FORK"] = process.env.HARDHAT_FORK
-}
-
-let config: HardhatUserConfig = {
+const config: HardhatUserConfig = {
   defaultNetwork: "hardhat",
   networks: {
     hardhat: {
@@ -25,6 +20,7 @@ let config: HardhatUserConfig = {
     },
     mainnet: {
       url: ALCHEMY_BASE_URL[CHAIN_ID.MAINNET] + process.env.ALCHEMY_API_KEY,
+      chainId: parseInt(CHAIN_ID.MAINNET),
       deploy: ["./deploy/mainnet/"],
       verify: {
         etherscan: {
@@ -35,6 +31,7 @@ let config: HardhatUserConfig = {
     },
     ropsten: {
       url: ALCHEMY_BASE_URL[CHAIN_ID.ROPSTEN] + process.env.ALCHEMY_API_KEY,
+      chainId: parseInt(CHAIN_ID.ROPSTEN),
       accounts: {
         mnemonic: process.env.MNEMONIC_TEST_ACCOUNT,
       },
@@ -44,7 +41,7 @@ let config: HardhatUserConfig = {
       url:
         ALCHEMY_BASE_URL[CHAIN_ID.ARBITRUM_TESTNET] +
         process.env.ALCHEMY_API_KEY,
-      chainId: 421611,
+      chainId: parseInt(CHAIN_ID.ROPSTEN),
       accounts: {
         mnemonic: process.env.MNEMONIC_TEST_ACCOUNT,
       },
@@ -52,7 +49,7 @@ let config: HardhatUserConfig = {
     },
     arbitrum_mainnet: {
       url: "https://arb1.arbitrum.io/rpc",
-      chainId: 42161,
+      chainId: parseInt(CHAIN_ID.ARBITRUM_MAINNET),
       deploy: ["./deploy/arbitrum/"],
       verify: {
         etherscan: {
@@ -63,7 +60,7 @@ let config: HardhatUserConfig = {
     },
     optimism_testnet: {
       url: "https://kovan.optimism.io",
-      chainId: 69,
+      chainId: parseInt(CHAIN_ID.OPTIMISM_TESTNET),
       accounts: {
         mnemonic: process.env.MNEMONIC_TEST_ACCOUNT,
       },
@@ -71,7 +68,7 @@ let config: HardhatUserConfig = {
     },
     optimism_mainnet: {
       url: "https://mainnet.optimism.io",
-      chainId: 10,
+      chainId: parseInt(CHAIN_ID.OPTIMISM_MAINNET),
       deploy: ["./deploy/optimism/"],
       verify: {
         etherscan: {
@@ -82,7 +79,7 @@ let config: HardhatUserConfig = {
     },
     fantom_testnet: {
       url: "https://rpc.testnet.fantom.network/",
-      chainId: 4002,
+      chainId: parseInt(CHAIN_ID.FANTOM_TESTNET),
       accounts: {
         mnemonic: process.env.MNEMONIC_TEST_ACCOUNT,
       },
@@ -90,7 +87,7 @@ let config: HardhatUserConfig = {
     },
     fantom_mainnet: {
       url: "https://rpc.ftm.tools/",
-      chainId: 250,
+      chainId: parseInt(CHAIN_ID.FANTOM_MAINNET),
       deploy: ["./deploy/fantom/"],
       verify: {
         etherscan: {
@@ -101,7 +98,7 @@ let config: HardhatUserConfig = {
     },
     evmos_testnet: {
       url: "https://eth.bd.evmos.dev:8545",
-      chainId: 9000,
+      chainId: parseInt(CHAIN_ID.EVMOS_TESTNET),
       deploy: ["./deploy/evmos_testnet/"],
       accounts: {
         mnemonic: process.env.MNEMONIC_TEST_ACCOUNT,
@@ -110,7 +107,7 @@ let config: HardhatUserConfig = {
     evmos_mainnet: {
       live: true,
       url: "https://eth.bd.evmos.org:8545",
-      chainId: 9001,
+      chainId: parseInt(CHAIN_ID.EVMOS_MAINNET),
       deploy: ["./deploy/evmos/"],
       verify: {
         etherscan: {
@@ -121,7 +118,7 @@ let config: HardhatUserConfig = {
     },
     kava_testnet: {
       url: "https://evm.evm-alpha.kava.io",
-      chainId: 2221,
+      chainId: parseInt(CHAIN_ID.KAVA_TESTNET),
       deploy: ["./deploy/kava_testnet/"],
       verify: {
         etherscan: {
@@ -135,7 +132,7 @@ let config: HardhatUserConfig = {
     kava_mainnet: {
       live: true,
       url: "https://evm.kava.io",
-      chainId: 2222,
+      chainId: parseInt(CHAIN_ID.KAVA_MAINNET),
       deploy: ["./deploy/kava_mainnet/"],
       verify: {
         etherscan: {
@@ -275,124 +272,5 @@ if (process.env.ACCOUNT_PRIVATE_KEYS) {
     },
   }
 }
-
-if (process.env.FORK_NETWORK && config.networks) {
-  const forkNetworkName = process.env.FORK_NETWORK as string
-  const blockNumber = process.env.FORK_BLOCK_NUMBER
-    ? parseInt(process.env.FORK_BLOCK_NUMBER)
-    : undefined
-  console.log(`FORK_NETWORK is set to ${forkNetworkName}`)
-  console.log(
-    `FORK_BLOCK_NUMBER is set to ${
-      blockNumber ? blockNumber : "undefined (using latest block number)"
-    }`,
-  )
-
-  if (!config.networks[forkNetworkName]) {
-    throw new Error(
-      `FORK_NETWORK is set to ${forkNetworkName}, but no network with that name is defined in the config.`,
-    )
-  }
-  if (!(config.networks[forkNetworkName] as HttpNetworkUserConfig).url) {
-    throw new Error(
-      `FORK_NETWORK is set to ${forkNetworkName}, but no url is defined for that network in the config.`,
-    )
-  }
-  if (!CHAIN_ID[forkNetworkName.toUpperCase()]) {
-    throw new Error(
-      `FORK_NETWORK is set to ${forkNetworkName}, but no chainId is defined for that network in the CHAIN_ID constant.`,
-    )
-  }
-  const forkingURL = (config.networks[forkNetworkName] as HttpNetworkUserConfig)
-    .url as string
-  const forkingChainId = parseInt(CHAIN_ID[forkNetworkName.toUpperCase()])
-  const externalDeploymentsFolder = `deployments/${forkNetworkName.toLowerCase()}`
-  const deployPaths = config.networks[forkNetworkName]?.deploy as string[]
-
-  console.log(
-    `Attempting to fork ${forkNetworkName} from ${forkingURL} with chainID of ${forkingChainId}. External deployments folder is ${externalDeploymentsFolder}`,
-  )
-
-  config = {
-    ...config,
-    networks: {
-      ...config.networks,
-      hardhat: {
-        ...config.networks.hardhat,
-        forking: {
-          url: forkingURL,
-          blockNumber: blockNumber,
-        },
-        chainId: forkingChainId,
-        deploy: deployPaths,
-      },
-    },
-    namedAccounts: {
-      ...config.namedAccounts,
-      deployer: {
-        [String(forkingChainId)]: PROD_DEPLOYER_ADDRESS,
-      },
-      multisig: {
-        [String(forkingChainId)]: MULTISIG_ADDRESSES[forkingChainId.toString()],
-      },
-    },
-    external: {
-      deployments: {
-        localhost: [externalDeploymentsFolder],
-      },
-    },
-  }
-}
-
-// Override the default deploy task
-task("deploy", async (taskArgs, hre, runSuper) => {
-  const { all } = hre.deployments
-  /*
-   * Pre-deployment actions
-   */
-
-  // Load exiting deployments
-  const existingDeployments: { [p: string]: Deployment } = await all()
-  // Create hard copy of existing deployment name to address mapping
-  const existingDeploymentToAddressMap: { [p: string]: string } = Object.keys(
-    existingDeployments,
-  ).reduce((acc: { [p: string]: string }, key) => {
-    acc[key] = existingDeployments[key].address
-    return acc
-  }, {})
-
-  /*
-   * Run super task
-   */
-  await runSuper(taskArgs)
-
-  /*
-   * Post-deployment actions
-   */
-  const updatedDeployments: { [p: string]: Deployment } = await all()
-
-  // Filter out any existing deployments that have not changed
-  const newDeployments: { [p: string]: Deployment } = Object.keys(
-    updatedDeployments,
-  ).reduce((acc: { [p: string]: Deployment }, key) => {
-    if (
-      !existingDeploymentToAddressMap.hasOwnProperty(key) ||
-      existingDeploymentToAddressMap[key] !== updatedDeployments[key].address
-    ) {
-      acc[key] = updatedDeployments[key]
-    }
-    return acc
-  }, {})
-
-  // Print the new deployments to the console
-  if (Object.keys(newDeployments).length > 0) {
-    console.log("\nNew deployments:")
-    console.table(
-      Object.keys(newDeployments).map((k) => [k, newDeployments[k].address]),
-    )
-  } else {
-    console.warn("\nNo new deployments found")
-  }
-})
 
 export default config

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@openzeppelin/contracts-upgradeable": "3.4.1",
         "@openzeppelin/contracts-upgradeable-4.2.0": "npm:@openzeppelin/contracts-upgradeable@4.2.0",
         "dotenv": "^10.0.0",
-        "dotenv-cli": "^4.1.1",
         "synthetix": "2.56.1"
       },
       "devDependencies": {
@@ -4526,6 +4525,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4959,33 +4959,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/dotenv-cli": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-4.1.1.tgz",
-      "integrity": "sha512-XvKv1pa+UBrsr3CtLGBsR6NdsoS7znqaHUf4Knj0eZO+gOI/hjj9KgWDP+KjpfEbj6wAba1UpbhaP9VezNkWhg==",
-      "dependencies": {
-        "cross-spawn": "^7.0.1",
-        "dotenv": "^8.1.0",
-        "dotenv-expand": "^5.1.0",
-        "minimist": "^1.1.3"
-      },
-      "bin": {
-        "dotenv": "cli.js"
-      }
-    },
-    "node_modules/dotenv-cli/node_modules/dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/dotenv-expand": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
-      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
     },
     "node_modules/duplexer3": {
       "version": "0.1.4",
@@ -9711,7 +9684,8 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
     },
     "node_modules/isobject": {
       "version": "2.1.0",
@@ -10487,7 +10461,8 @@
     "node_modules/minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "node_modules/minipass": {
       "version": "2.9.0",
@@ -11801,6 +11776,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -13483,6 +13459,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -13494,6 +13471,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -16948,6 +16926,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -20781,6 +20760,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -21110,29 +21090,6 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
-    },
-    "dotenv-cli": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-4.1.1.tgz",
-      "integrity": "sha512-XvKv1pa+UBrsr3CtLGBsR6NdsoS7znqaHUf4Knj0eZO+gOI/hjj9KgWDP+KjpfEbj6wAba1UpbhaP9VezNkWhg==",
-      "requires": {
-        "cross-spawn": "^7.0.1",
-        "dotenv": "^8.1.0",
-        "dotenv-expand": "^5.1.0",
-        "minimist": "^1.1.3"
-      },
-      "dependencies": {
-        "dotenv": {
-          "version": "8.6.0",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-          "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="
-        }
-      }
-    },
-    "dotenv-expand": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
-      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -24797,7 +24754,8 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
     },
     "isobject": {
       "version": "2.1.0",
@@ -25433,7 +25391,8 @@
     "minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "minipass": {
       "version": "2.9.0",
@@ -26446,7 +26405,8 @@
     "path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.7",
@@ -27766,6 +27726,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
       }
@@ -27773,7 +27734,8 @@
     "shebang-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
     },
     "shelljs": {
       "version": "0.8.5",
@@ -30548,6 +30510,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@openzeppelin/contracts-upgradeable": "3.4.1",
     "@openzeppelin/contracts-upgradeable-4.2.0": "npm:@openzeppelin/contracts-upgradeable@4.2.0",
     "dotenv": "^10.0.0",
-    "dotenv-cli": "^4.1.1",
     "synthetix": "2.56.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "coverage": "hardhat coverage --temp ./build/artifacts",
     "deploy": "hardhat deploy",
     "start": "hardhat node",
-    "fork": "dotenv -v FORK_NETWORK=$npm_config_network hardhat node",
+    "fork": "hardhat node --fork $npm_config_network",
     "prepare": "npm run build",
     "addresses": "node scripts/print-addresses.js"
   },

--- a/scripts/calculateMinichefOwed.ts
+++ b/scripts/calculateMinichefOwed.ts
@@ -1,7 +1,8 @@
-import { ethers, deployments, network } from "hardhat"
+import { ethers, deployments, network, getChainId, config } from "hardhat"
 import { BigNumber } from "ethers"
 import fetch from "node-fetch"
 import { MiniChefV2, SDL } from "../build/typechain"
+import { getNetworkNameFromChainId } from "../utils/network"
 
 interface TimeToRateMap {
   [timestamp: number]: BigNumber
@@ -10,9 +11,11 @@ interface TimeToRateMap {
 async function main() {
   const latestBlock = await ethers.provider.getBlock("latest")
   const latestBlockTimestamp = latestBlock.timestamp
+  const chainId = await getChainId()
+  const networkConfig = config.networks[getNetworkNameFromChainId(chainId)]
 
-  const etherscanAPIUrl = network.verify?.etherscan?.apiUrl
-  const etherscanAPIKey = network.verify?.etherscan?.apiKey
+  const etherscanAPIUrl = networkConfig.verify?.etherscan?.apiUrl
+  const etherscanAPIKey = networkConfig.verify?.etherscan?.apiKey
   if (!etherscanAPIUrl) {
     throw new Error(
       `No etherscan API URL found in hardhat.config.js file for network ${network.name}`,

--- a/scripts/forked_mainnet/enableOnChainGaugeVoting.ts
+++ b/scripts/forked_mainnet/enableOnChainGaugeVoting.ts
@@ -2,7 +2,6 @@ import { ethers, network } from "hardhat"
 import { GaugeController, SDL } from "../../build/typechain"
 import { getHardhatTestSigners, logNetworkDetails } from "../utils"
 import GaugeControllerDeployment from "../../deployments/mainnet/GaugeController.json"
-import SDLDeployment from "../../deployments/mainnet/SDL.json"
 import { impersonateAccount, setEtherBalance } from "../../test/testUtils"
 import { MULTISIG_ADDRESSES } from "../../utils/accounts"
 import { CHAIN_ID } from "../../utils/network"
@@ -29,7 +28,7 @@ async function main() {
   )
 
   // Send 1000 SDL from multisig to hardhat test account
-  const sdl: SDL = await ethers.getContractAt("SDL", SDLDeployment.address)
+  const sdl: SDL = await ethers.getContract("SDL")
   await sdl
     .connect(multisig)
     .transfer(hardhatTestAccountAddress, ethers.constants.WeiPerEther.mul(1000))

--- a/tasks/deploy.ts
+++ b/tasks/deploy.ts
@@ -5,7 +5,9 @@ import {
   convertDeploymentsToSimpleAddressMap,
 } from "./utils"
 
-// Override the default deploy task
+/*
+ * Prints a table with the new deployments name and address
+ */
 task("deploy", async (taskArgs, hre, runSuper) => {
   const { all } = hre.deployments
   /*

--- a/tasks/deploy.ts
+++ b/tasks/deploy.ts
@@ -1,0 +1,28 @@
+import "hardhat-deploy"
+import { task } from "hardhat/config"
+import {
+  compareDeployments,
+  convertDeploymentsToSimpleAddressMap,
+} from "./utils"
+
+// Override the default deploy task
+task("deploy", async (taskArgs, hre, runSuper) => {
+  const { all } = hre.deployments
+  /*
+   * Pre-deployment actions
+   */
+
+  // Load exiting deployments
+  const existingDeployments = convertDeploymentsToSimpleAddressMap(await all())
+
+  /*
+   * Run super task
+   */
+  await runSuper(taskArgs)
+
+  /*
+   * Post-deployment actions
+   */
+  const updatedDeployments = convertDeploymentsToSimpleAddressMap(await all())
+  compareDeployments(existingDeployments, updatedDeployments)
+})

--- a/tasks/index.ts
+++ b/tasks/index.ts
@@ -1,0 +1,3 @@
+import "./node"
+import "./deploy"
+import "./run"

--- a/tasks/node.ts
+++ b/tasks/node.ts
@@ -6,7 +6,11 @@ import {
   convertDeploymentsToSimpleAddressMap,
 } from "./utils"
 
-// Override the default node task
+/*
+ * Extends the --fork option to parse network names
+ * example: hardhat node --fork arbitrum_mainnet --fork-block-number 111111
+ *          hardhat node --fork mainnet
+ */
 task("node", "Starts a JSON-RPC server on top of Hardhat Network").setAction(
   async (taskArgs, hre, runSuper) => {
     const { all } = hre.deployments

--- a/tasks/node.ts
+++ b/tasks/node.ts
@@ -1,0 +1,87 @@
+import "hardhat-deploy"
+import { task } from "hardhat/config"
+import { NetworkUserConfig } from "hardhat/types"
+import {
+  compareDeployments,
+  convertDeploymentsToSimpleAddressMap,
+} from "./utils"
+
+// Override the default node task
+task("node", "Starts a JSON-RPC server on top of Hardhat Network").setAction(
+  async (taskArgs, hre, runSuper) => {
+    const { all } = hre.deployments
+    /*
+     * Pre actions
+     */
+
+    // Forks an existing network if the given argument is a network name
+    const network: NetworkUserConfig | undefined =
+      hre.userConfig?.networks?.[taskArgs.fork]
+    let prevDeployments = undefined
+    if (network) {
+      const networkName = taskArgs.fork
+      console.log(`Found matching network name, ${networkName}`)
+
+      // Workaround for hardhat-deploy issue #115 https://github.com/wighawag/hardhat-deploy/issues/115
+      process.env["HARDHAT_DEPLOY_FORK"] = networkName
+      const externalDeploymentsFolder = `deployments/${networkName}`
+
+      if ("url" in network) {
+        console.log(`Forking ${networkName} from RPC: ${network.url}`)
+
+        // Set the task arguments for the super call
+        taskArgs.noReset = true
+        taskArgs.fork = network.url
+
+        console.log(
+          `Forking with deployments from ${externalDeploymentsFolder}`,
+        )
+
+        if (network.chainId) {
+          hre.config.networks.hardhat.chainId = network.chainId
+          hre.config.networks.localhost.chainId = network.chainId
+        }
+
+        if (network.deploy) {
+          hre.config.networks.hardhat.deploy = network.deploy as string[]
+          hre.config.networks.localhost.deploy = network.deploy as string[]
+        }
+
+        if (network.verify) {
+          hre.config.networks.hardhat.verify = network.verify
+          hre.config.networks.localhost.verify = network.verify
+        }
+
+        hre.config.external = {
+          ...hre.config.external,
+          deployments: {
+            ...hre.config.external?.deployments,
+            hardhat: [externalDeploymentsFolder],
+            localhost: [externalDeploymentsFolder],
+          },
+        }
+      } else {
+        throw new Error(
+          `Could not find url to fork inside the "${networkName}" network config`,
+        )
+      }
+
+      prevDeployments = convertDeploymentsToSimpleAddressMap(await all())
+    }
+
+    /*
+     * Super actions
+     */
+    await runSuper(taskArgs)
+
+    /*
+     * Post actions
+     */
+    if (prevDeployments) {
+      compareDeployments(
+        prevDeployments,
+        convertDeploymentsToSimpleAddressMap(await all()),
+      )
+    }
+  },
+)

--- a/tasks/run.ts
+++ b/tasks/run.ts
@@ -2,12 +2,17 @@ import "hardhat-deploy"
 import { task, types } from "hardhat/config"
 import { NetworkUserConfig } from "hardhat/types"
 
-// Override the default run task
+/*
+ * Allows run command to specify which network to read deployments from
+ * This is useful when you have running hardhat network like `hardhat node --fork mainnet`
+ * and want to connect to it with existing deployments.
+ * example: hardhat --network localhost run --include-network mainnet
+ */
 task("run", "Starts a JSON-RPC server on top of Hardhat Network")
   .addOptionalParam(
-    "fork",
-    "The name of the network that localhost is running",
-    "localhost",
+    "include-network",
+    "The name of the network to include the deployments from. Only valid when running with --network localhost",
+    "hardhat",
     types.string,
   )
   .setAction(async (taskArgs, hre, runSuper) => {
@@ -15,17 +20,20 @@ task("run", "Starts a JSON-RPC server on top of Hardhat Network")
      * Pre actions
      */
 
-    if (taskArgs.fork && hre.hardhatArguments.network !== "localhost") {
+    if (
+      taskArgs["include-network"] &&
+      hre.hardhatArguments.network !== "localhost"
+    ) {
       throw new Error(
-        `--fork can only be used when using run command with "--network localhost"`,
+        `--include-network can only be used when using run command with "--network localhost"`,
       )
     }
 
     // Forks an existing network if the given argument is a network name
     const network: NetworkUserConfig | undefined =
-      hre.userConfig?.networks?.[taskArgs.fork]
+      hre.userConfig?.networks?.[taskArgs["include-network"]]
     if (network) {
-      const networkName = taskArgs.fork
+      const networkName = taskArgs["include-network"]
       console.log(`Found matching network name, ${networkName}`)
 
       // Workaround for hardhat-deploy issue #115 https://github.com/wighawag/hardhat-deploy/issues/115

--- a/tasks/run.ts
+++ b/tasks/run.ts
@@ -1,0 +1,67 @@
+import "hardhat-deploy"
+import { task, types } from "hardhat/config"
+import { NetworkUserConfig } from "hardhat/types"
+
+// Override the default run task
+task("run", "Starts a JSON-RPC server on top of Hardhat Network")
+  .addOptionalParam(
+    "fork",
+    "The name of the network that localhost is running",
+    "localhost",
+    types.string,
+  )
+  .setAction(async (taskArgs, hre, runSuper) => {
+    /*
+     * Pre actions
+     */
+
+    if (taskArgs.fork && hre.hardhatArguments.network !== "localhost") {
+      throw new Error(
+        `--fork can only be used when using run command with "--network localhost"`,
+      )
+    }
+
+    // Forks an existing network if the given argument is a network name
+    const network: NetworkUserConfig | undefined =
+      hre.userConfig?.networks?.[taskArgs.fork]
+    if (network) {
+      const networkName = taskArgs.fork
+      console.log(`Found matching network name, ${networkName}`)
+
+      // Workaround for hardhat-deploy issue #115 https://github.com/wighawag/hardhat-deploy/issues/115
+      process.env["HARDHAT_DEPLOY_FORK"] = networkName
+      const externalDeploymentsFolder = `deployments/${networkName}`
+
+      if ("url" in network) {
+        console.log(
+          `Using existing deployments from ${externalDeploymentsFolder}`,
+        )
+
+        if (network.chainId) {
+          hre.config.networks.hardhat.chainId = network.chainId
+          hre.config.networks.localhost.chainId = network.chainId
+          hre.network.config.chainId = network.chainId
+        }
+
+        if (network.verify) {
+          hre.config.networks.hardhat.verify = network.verify
+          hre.config.networks.localhost.verify = network.verify
+          hre.network.verify = network.verify
+        }
+
+        hre.config.external = {
+          ...hre.config.external,
+          deployments: {
+            ...hre.config.external?.deployments,
+            hardhat: [externalDeploymentsFolder],
+            localhost: [externalDeploymentsFolder],
+          },
+        }
+      }
+    }
+
+    /*
+     * Super actions
+     */
+    await runSuper(taskArgs)
+  })

--- a/tasks/run.ts
+++ b/tasks/run.ts
@@ -6,11 +6,11 @@ import { NetworkUserConfig } from "hardhat/types"
  * Allows run command to specify which network to read deployments from
  * This is useful when you have running hardhat network like `hardhat node --fork mainnet`
  * and want to connect to it with existing deployments.
- * example: hardhat --network localhost run --include-network mainnet
+ * example: hardhat --network localhost run --includeNetwork mainnet
  */
 task("run", "Starts a JSON-RPC server on top of Hardhat Network")
   .addOptionalParam(
-    "include-network",
+    "includeNetwork",
     "The name of the network to include the deployments from. Only valid when running with --network localhost",
     "hardhat",
     types.string,
@@ -21,19 +21,19 @@ task("run", "Starts a JSON-RPC server on top of Hardhat Network")
      */
 
     if (
-      taskArgs["include-network"] &&
+      taskArgs.includeNetwork &&
       hre.hardhatArguments.network !== "localhost"
     ) {
       throw new Error(
-        `--include-network can only be used when using run command with "--network localhost"`,
+        `--includeNetwork can only be used when using run command with "--network localhost"`,
       )
     }
 
     // Forks an existing network if the given argument is a network name
     const network: NetworkUserConfig | undefined =
-      hre.userConfig?.networks?.[taskArgs["include-network"]]
+      hre.userConfig?.networks?.[taskArgs.includeNetwork]
     if (network) {
-      const networkName = taskArgs["include-network"]
+      const networkName = taskArgs.includeNetwork
       console.log(`Found matching network name, ${networkName}`)
 
       // Workaround for hardhat-deploy issue #115 https://github.com/wighawag/hardhat-deploy/issues/115

--- a/tasks/utils.ts
+++ b/tasks/utils.ts
@@ -1,0 +1,38 @@
+import { Address, Deployment } from "hardhat-deploy/dist/types"
+
+export function compareDeployments(
+  prevDeplyments: { [contractName: string]: Address },
+  currDeployments: { [contractName: string]: Address },
+) {
+  // Filter out any existing deployments that have not changed
+  const newDeployments: { [contractName: string]: Address } = Object.keys(
+    currDeployments,
+  ).reduce((acc: { [contractName: string]: Address }, key) => {
+    if (
+      !currDeployments.hasOwnProperty(key) ||
+      prevDeplyments[key] !== currDeployments[key]
+    ) {
+      acc[key] = currDeployments[key]
+    }
+    return acc
+  }, {})
+
+  // Print the new deployments to the console
+  if (Object.keys(newDeployments).length > 0) {
+    console.log("\nNew deployments:")
+    console.table(newDeployments)
+  } else {
+    console.warn("\nNo new deployments found")
+  }
+}
+
+export function convertDeploymentsToSimpleAddressMap(deploymentMap: {
+  [p: string]: Deployment
+}): { [p: string]: Address } {
+  return Object.entries(deploymentMap).reduce(
+    (acc: { [p: string]: string }, [k, v]) => {
+      return { ...acc, [k]: v.address }
+    },
+    {},
+  )
+}

--- a/tasks/utils.ts
+++ b/tasks/utils.ts
@@ -1,7 +1,13 @@
 import { Address, Deployment } from "hardhat-deploy/dist/types"
 
+/**
+ * Prints a table with the new deployments name and address.
+ * Both parameters are object type of { [contractName: string]: string }
+ * @param prevDeployments Object containing the names and addresses of previous deployments
+ * @param currDeployments Object containing the names and addresses of current deployments
+ */
 export function compareDeployments(
-  prevDeplyments: { [contractName: string]: Address },
+  prevDeployments: { [contractName: string]: Address },
   currDeployments: { [contractName: string]: Address },
 ) {
   // Filter out any existing deployments that have not changed
@@ -10,7 +16,7 @@ export function compareDeployments(
   ).reduce((acc: { [contractName: string]: Address }, key) => {
     if (
       !currDeployments.hasOwnProperty(key) ||
-      prevDeplyments[key] !== currDeployments[key]
+      prevDeployments[key] !== currDeployments[key]
     ) {
       acc[key] = currDeployments[key]
     }
@@ -26,6 +32,11 @@ export function compareDeployments(
   }
 }
 
+/**
+ * Converts the deployments from the hardhat-deploy library to a simple address map
+ * @param deploymentMap The deployments you get from the hardhat-deploy library using functions like all()
+ * @returns Object with key value pairs of contract name to address
+ */
 export function convertDeploymentsToSimpleAddressMap(deploymentMap: {
   [p: string]: Deployment
 }): { [p: string]: Address } {

--- a/utils/network.ts
+++ b/utils/network.ts
@@ -3,6 +3,7 @@ import dotenv from "dotenv"
 
 dotenv.config()
 
+// Record of chain name to chain id
 export const CHAIN_ID: Record<string, string> = {
   MAINNET: "1",
   ROPSTEN: "3",
@@ -18,6 +19,16 @@ export const CHAIN_ID: Record<string, string> = {
   EVMOS_MAINNET: "9001",
   KAVA_TESTNET: "2221",
   KAVA_MAINNET: "2222",
+}
+
+// Reverse lookup of chainId to chain name
+export function getNetworkNameFromChainId(chainId: string): string {
+  for (const [name, id] of Object.entries(CHAIN_ID)) {
+    if (id === chainId) {
+      return name.toLowerCase()
+    }
+  }
+  throw new Error(`Unknown chain id: ${chainId}`)
 }
 
 export function isMainnet(networkId: string): boolean {


### PR DESCRIPTION
Changes fork to be part of hardhat task. Modifies run task to be able to specify which external deployments to include when targetting localhost network.

=========

Example usages:
Forks arbitrum_mainnet @ block number 111111 and runs any deploy scripts associated with that network
```
hardhat node --fork arbitrum_mainnet --fork-block-number 111111 // uses network information from hardhat.config.ts
```

Runs scripts/pwn.ts targetting localhost RPC but includes deployment info from mainnet
This allows scripts to use functions such as `getContractAt` `getContractFactoryAt` etc which relies on fetching via deployment json names.
```
hardhat --network localhost run scripts/pwn.ts --include-network mainnet
```


Combining two commands, you can successfully run any script you want against forked network environment and still get the benefits of knowing deployments + hardhat toolbox