### PR TITLE
Adds 2 new node dependencies

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -2,6 +2,7 @@ import "@nomicfoundation/hardhat-toolbox"
 import "@nomiclabs/hardhat-vyper"
 import "hardhat-deploy"
 import "hardhat-spdx-license-identifier"
+import "hardhat-tracer"
 
 import { HardhatUserConfig, task } from "hardhat/config"
 import dotenv from "dotenv"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,10 @@
         "@openzeppelin/contracts-4.4.0": "npm:@openzeppelin/contracts@4.4.0",
         "@openzeppelin/contracts-upgradeable": "3.4.1",
         "@openzeppelin/contracts-upgradeable-4.2.0": "npm:@openzeppelin/contracts-upgradeable@4.2.0",
+        "@openzeppelin/contracts-upgradeable-4.4.0": "npm:@openzeppelin/contracts-upgradeable@4.4.0",
         "dotenv": "^10.0.0",
         "dotenv-cli": "^4.1.1",
+        "hardhat-tracer": "^1.1.0-rc.8",
         "synthetix": "2.56.1"
       },
       "devDependencies": {
@@ -407,7 +409,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
       "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -483,7 +484,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
       "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -537,7 +537,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
       "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -567,7 +566,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
       "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -650,7 +648,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
       "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -688,7 +685,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.0.tgz",
       "integrity": "sha512-+TTrrINMzZ0aXtlwO/95uhAggKm4USLm1PbeCBR/3XZ7+Oey+3pMyddzZEyRhizHpy1HXV0FRWRMI1O3EGYibA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -726,7 +722,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
       "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -765,7 +760,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
       "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -809,7 +803,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
       "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -879,7 +872,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
       "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -900,7 +892,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
       "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -955,7 +946,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
       "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1801,6 +1791,12 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.2.0.tgz",
       "integrity": "sha512-vn0hoUqQzgOLzLZwFgh+w/D5hzJHX8F7X/7t/gZdSQYIEXMyGpXUwkr5A3eoAeoc42f/n7yDhwusvBmNknM41Q=="
+    },
+    "node_modules/@openzeppelin/contracts-upgradeable-4.4.0": {
+      "name": "@openzeppelin/contracts-upgradeable",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.4.0.tgz",
+      "integrity": "sha512-hIEyWJHu7bDTv6ckxOaV+K3+7mVzhjtyvp3QSaz56Rk5PscXtPAbkiNTb3yz6UJCWHPWpxVyULVgZ6RubuFEZg=="
     },
     "node_modules/@scure/base": {
       "version": "1.1.1",
@@ -2684,8 +2680,7 @@
     "node_modules/aes-js": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
-      "dev": true
+      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
@@ -3188,8 +3183,7 @@
     "node_modules/bech32": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
-      "dev": true
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "node_modules/bignumber.js": {
       "version": "9.0.2",
@@ -6529,7 +6523,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.0.tgz",
       "integrity": "sha512-5Xhzp2ZQRi0Em+0OkOcRHxPzCfoBfgtOQA+RUylSkuHbhTEaQklnYi2hsWbRgs3ztJsXVXd9VKBcO1ScWL8YfA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -8178,6 +8171,19 @@
       "dev": true,
       "peerDependencies": {
         "hardhat": "^2.0.0"
+      }
+    },
+    "node_modules/hardhat-tracer": {
+      "version": "1.1.0-rc.8",
+      "resolved": "https://registry.npmjs.org/hardhat-tracer/-/hardhat-tracer-1.1.0-rc.8.tgz",
+      "integrity": "sha512-BvKj37IilIspy1ZcNzngio67xxLV6Bzvv3CVNzD41w81aYV07/C+cj76mX8fxSveagquYkW5WpUPu6is5a3MLg==",
+      "dependencies": {
+        "ethers": "^5.6.1"
+      },
+      "peerDependencies": {
+        "chalk": "4.x",
+        "ethers": "5.x",
+        "hardhat": "2.x"
       }
     },
     "node_modules/hardhat/node_modules/@noble/hashes": {
@@ -17154,7 +17160,6 @@
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
       "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-      "dev": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -17622,7 +17627,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
       "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/properties": "^5.7.0"
@@ -17658,7 +17662,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
       "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
-      "dev": true,
       "requires": {
         "@ethersproject/abi": "^5.7.0",
         "@ethersproject/abstract-provider": "^5.7.0",
@@ -17692,7 +17695,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
       "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
-      "dev": true,
       "requires": {
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/basex": "^5.7.0",
@@ -17712,7 +17714,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
       "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
-      "dev": true,
       "requires": {
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/address": "^5.7.0",
@@ -17755,7 +17756,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
       "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/sha2": "^5.7.0"
@@ -17773,7 +17773,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.0.tgz",
       "integrity": "sha512-+TTrrINMzZ0aXtlwO/95uhAggKm4USLm1PbeCBR/3XZ7+Oey+3pMyddzZEyRhizHpy1HXV0FRWRMI1O3EGYibA==",
-      "dev": true,
       "requires": {
         "@ethersproject/abstract-provider": "^5.7.0",
         "@ethersproject/abstract-signer": "^5.7.0",
@@ -17801,7 +17800,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
       "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0"
@@ -17820,7 +17818,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
       "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0",
@@ -17844,7 +17841,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
       "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
-      "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
@@ -17884,7 +17880,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
       "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
-      "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/constants": "^5.7.0",
@@ -17895,7 +17890,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
       "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
-      "dev": true,
       "requires": {
         "@ethersproject/abstract-provider": "^5.7.0",
         "@ethersproject/abstract-signer": "^5.7.0",
@@ -17930,7 +17924,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
       "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/hash": "^5.7.0",
@@ -18588,6 +18581,11 @@
       "version": "npm:@openzeppelin/contracts-upgradeable@4.2.0",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.2.0.tgz",
       "integrity": "sha512-vn0hoUqQzgOLzLZwFgh+w/D5hzJHX8F7X/7t/gZdSQYIEXMyGpXUwkr5A3eoAeoc42f/n7yDhwusvBmNknM41Q=="
+    },
+    "@openzeppelin/contracts-upgradeable-4.4.0": {
+      "version": "npm:@openzeppelin/contracts-upgradeable@4.4.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.4.0.tgz",
+      "integrity": "sha512-hIEyWJHu7bDTv6ckxOaV+K3+7mVzhjtyvp3QSaz56Rk5PscXtPAbkiNTb3yz6UJCWHPWpxVyULVgZ6RubuFEZg=="
     },
     "@scure/base": {
       "version": "1.1.1",
@@ -19277,8 +19275,7 @@
     "aes-js": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
-      "dev": true
+      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
     },
     "agent-base": {
       "version": "6.0.2",
@@ -19672,8 +19669,7 @@
     "bech32": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
-      "dev": true
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "bignumber.js": {
       "version": "9.0.2",
@@ -22353,7 +22349,6 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.0.tgz",
       "integrity": "sha512-5Xhzp2ZQRi0Em+0OkOcRHxPzCfoBfgtOQA+RUylSkuHbhTEaQklnYi2hsWbRgs3ztJsXVXd9VKBcO1ScWL8YfA==",
-      "dev": true,
       "requires": {
         "@ethersproject/abi": "5.7.0",
         "@ethersproject/abstract-provider": "5.7.0",
@@ -23903,6 +23898,14 @@
       "resolved": "https://registry.npmjs.org/hardhat-spdx-license-identifier/-/hardhat-spdx-license-identifier-2.0.3.tgz",
       "integrity": "sha512-G4u4I1md0tWaitX6Os7Nq9sYZ/CFdR+ibm7clCksGJ4yrtdHEZxgLjWpJ0WiALF9SoFKt03PwCe9lczDQ/5ADA==",
       "dev": true
+    },
+    "hardhat-tracer": {
+      "version": "1.1.0-rc.8",
+      "resolved": "https://registry.npmjs.org/hardhat-tracer/-/hardhat-tracer-1.1.0-rc.8.tgz",
+      "integrity": "sha512-BvKj37IilIspy1ZcNzngio67xxLV6Bzvv3CVNzD41w81aYV07/C+cj76mX8fxSveagquYkW5WpUPu6is5a3MLg==",
+      "requires": {
+        "ethers": "^5.6.1"
+      }
     },
     "has": {
       "version": "1.0.3",
@@ -30711,8 +30714,7 @@
     "ws": {
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-      "dev": true
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
     },
     "xhr": {
       "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
     "@openzeppelin/contracts-4.4.0": "npm:@openzeppelin/contracts@4.4.0",
     "@openzeppelin/contracts-upgradeable": "3.4.1",
     "@openzeppelin/contracts-upgradeable-4.2.0": "npm:@openzeppelin/contracts-upgradeable@4.2.0",
+    "@openzeppelin/contracts-upgradeable-4.4.0": "npm:@openzeppelin/contracts-upgradeable@4.4.0",
     "dotenv": "^10.0.0",
     "dotenv-cli": "^4.1.1",
+    "hardhat-tracer": "^1.1.0-rc.8",
     "synthetix": "2.56.1"
   },
   "devDependencies": {

--- a/test/lpToken.ts
+++ b/test/lpToken.ts
@@ -15,7 +15,7 @@ describe("LPToken", async () => {
 
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
-      await deployments.fixture() // ensure you start from a fresh deployments
+      await deployments.fixture(["USDPool"]) // ensure you start from a fresh deployments
 
       signers = await ethers.getSigners()
       owner = signers[0]

--- a/test/swap.ts
+++ b/test/swap.ts
@@ -56,7 +56,7 @@ describe("Swap", async () => {
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
       const { get } = deployments
-      await deployments.fixture() // ensure you start from a fresh deployments
+      await deployments.fixture(["Swap", "LPToken"]) // ensure you start from a fresh deployments
 
       signers = await ethers.getSigners()
       owner = signers[0]


### PR DESCRIPTION
- hardhat-tracer
- openzepplin 4.4.0 upgradable

https://github.com/zemse/hardhat-tracer#usage

hardhat-tracer allows for detailed tracing and decoding calldata.