### PR TITLE
Adds `patch-package` to apply fix for Arbitrum Nitro

### DIFF
--- a/deploy/arbitrum/999_impersonate_owners.ts
+++ b/deploy/arbitrum/999_impersonate_owners.ts
@@ -27,26 +27,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // key = token deployment name, value = array of addresses
   const tokenToAccountsMap: Record<string, string[]> = {
     // USD
-    DAI: ["0xa5407eae9ba41422680e2e00537571bcc53efbfd"],
-    USDC: ["0xa5407eae9ba41422680e2e00537571bcc53efbfd"],
-    USDT: ["0xa5407eae9ba41422680e2e00537571bcc53efbfd"],
-    SUSD: ["0xa5407eae9ba41422680e2e00537571bcc53efbfd"],
-    // BTC
-    WBTC: ["0x7fc77b5c7614e1533320ea6ddc2eb61fa00a9714"],
-    RENBTC: ["0x7fc77b5c7614e1533320ea6ddc2eb61fa00a9714"],
-    SBTC: ["0x7fc77b5c7614e1533320ea6ddc2eb61fa00a9714"],
-    TBTC: ["0xC25099792E9349C7DD09759744ea681C7de2cb66"],
-    // ETH
-    ALETH: ["0x1d2c4cd9bee9dfe088430b95d274e765151c32db"],
-    WETH: ["0xceff51756c56ceffca006cd410b03ffc46dd3a58"],
-    SETH: ["0xc5424b857f758e906013f3555dad202e4bdb4567"],
-    // D4
-    ALUSD: ["0x43b4fdfd4ff969587185cdb6f0bd875c5fc83f8c"],
-    FEI: ["0x94b0a3d511b6ecdb17ebf877278ab030acb0a878"],
-    FRAX: ["0xd632f22692fac7611d2aa1c0d552930d43caed3b"],
-    LUSD: ["0x66017d22b0f8556afdd19fc67041899eb65a21bb"],
-    // TBTC
-    TBTCv2: ["0xf9e11762d522ea29dd78178c9baf83b7b093aacc"],
+    USDC: ["0x489ee077994B6658eAfA855C308275EAd8097C4A"],
+    FRAX: ["0x489ee077994b6658eafa855c308275ead8097c4a"],
+    USDT: ["0x489ee077994b6658eafa855c308275ead8097c4a"],
   }
 
   if (

--- a/deploy/hardhat/999_impersonate_owners.ts
+++ b/deploy/hardhat/999_impersonate_owners.ts
@@ -50,7 +50,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   if (
     isMainnet(await getChainId()) &&
-    process.env.FORK_NETWORK &&
+    process.env.HARDHAT_DEPLOY_FORK &&
     process.env.FUND_FORK_NETWORK
   ) {
     // Give the deployer tokens from each token holder for testing

--- a/deploy/mainnet/599_multisig_actions.ts
+++ b/deploy/mainnet/599_multisig_actions.ts
@@ -22,7 +22,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deploy, get, getOrNull, execute, read, log } = deployments
 
   // If we are not on forked mainnet, skip this file
-  if (process.env.FORK_NETWORK !== "mainnet") {
+  if (process.env.HARDHAT_DEPLOY_FORK !== "mainnet") {
     log(`Not running on forked mainnet, skipping...`)
     return
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "saddle-contract",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@boringcrypto/boring-solidity": "boringcrypto/BoringSolidity#f05de5f2",
@@ -19,6 +20,7 @@
         "@openzeppelin/contracts-upgradeable-4.4.0": "npm:@openzeppelin/contracts-upgradeable@4.4.0",
         "dotenv": "^10.0.0",
         "hardhat-tracer": "^1.1.0-rc.8",
+        "patch-package": "^6.4.7",
         "synthetix": "2.56.1"
       },
       "devDependencies": {
@@ -2572,6 +2574,11 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
+    },
     "node_modules/abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -3094,8 +3101,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base": {
       "version": "0.11.2",
@@ -3291,7 +3297,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3772,8 +3777,7 @@
     "node_modules/ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-      "dev": true
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
     },
     "node_modules/cids": {
       "version": "0.7.5",
@@ -4244,8 +4248,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
@@ -7172,6 +7175,48 @@
         "node": ">=4"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
+    "node_modules/find-yarn-workspace-root/node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-yarn-workspace-root/node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-yarn-workspace-root/node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
     "node_modules/flat": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -7322,7 +7367,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -7350,8 +7394,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/fsevents": {
       "version": "1.2.13",
@@ -7595,7 +7638,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -7782,8 +7824,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "node_modules/growl": {
       "version": "1.10.5",
@@ -8897,7 +8938,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -9268,6 +9308,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "dependencies": {
+        "ci-info": "^2.0.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
     "node_modules/is-data-descriptor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
@@ -9340,7 +9391,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -9673,7 +9723,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -9690,8 +9739,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/isobject": {
       "version": "2.1.0",
@@ -9852,7 +9900,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -9923,6 +9970,14 @@
       "dev": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.9"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/lcid": {
@@ -10456,7 +10511,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -10467,8 +10521,7 @@
     "node_modules/minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/minipass": {
       "version": "2.9.0",
@@ -11035,8 +11088,7 @@
     "node_modules/nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node_modules/node-addon-api": {
       "version": "2.0.2",
@@ -11456,6 +11508,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -11754,6 +11821,176 @@
         "which": "bin/which"
       }
     },
+    "node_modules/patch-package": {
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.4.7.tgz",
+      "integrity": "sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^2.4.2",
+        "cross-spawn": "^6.0.5",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^7.0.1",
+        "is-ci": "^2.0.0",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.0",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^5.6.0",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/patch-package/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/patch-package/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/patch-package/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/patch-package/node_modules/cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/patch-package/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/patch-package/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/patch-package/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/patch-package/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/patch-package/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/patch-package/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/patch-package/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/patch-package/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
     "node_modules/path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -11767,7 +12004,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11854,7 +12090,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -15746,7 +15981,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -15758,7 +15992,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -16241,7 +16474,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -19174,6 +19406,11 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
+    "@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
+    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -19579,8 +19816,7 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base": {
       "version": "0.11.2",
@@ -19743,7 +19979,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -20138,8 +20373,7 @@
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-      "dev": true
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
     },
     "cids": {
       "version": "0.7.5",
@@ -20523,8 +20757,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -22887,6 +23120,41 @@
         "locate-path": "^2.0.0"
       }
     },
+    "find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "requires": {
+        "micromatch": "^4.0.2"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "micromatch": {
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+          "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+          "requires": {
+            "braces": "^3.0.2",
+            "picomatch": "^2.3.1"
+          }
+        }
+      }
+    },
     "flat": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -22996,7 +23264,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -23021,8 +23288,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "fsevents": {
       "version": "1.2.13",
@@ -23206,7 +23472,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -23352,8 +23617,7 @@
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "growl": {
       "version": "1.10.5",
@@ -24184,7 +24448,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -24468,6 +24731,14 @@
       "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
       "dev": true
     },
+    "is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "requires": {
+        "ci-info": "^2.0.0"
+      }
+    },
     "is-data-descriptor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
@@ -24522,8 +24793,7 @@
     "is-docker": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -24743,7 +25013,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -24757,8 +25026,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "isobject": {
       "version": "2.1.0",
@@ -24894,7 +25162,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -24952,6 +25219,14 @@
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.9"
+      }
+    },
+    "klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "requires": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "lcid": {
@@ -25386,7 +25661,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -25394,8 +25668,7 @@
     "minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "minipass": {
       "version": "2.9.0",
@@ -25835,8 +26108,7 @@
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node-addon-api": {
       "version": "2.0.2",
@@ -26157,6 +26429,15 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "requires": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      }
+    },
     "optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -26387,6 +26668,133 @@
         }
       }
     },
+    "patch-package": {
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.4.7.tgz",
+      "integrity": "sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==",
+      "requires": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^2.4.2",
+        "cross-spawn": "^6.0.5",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^7.0.1",
+        "is-ci": "^2.0.0",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.0",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^5.6.0",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw=="
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ=="
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -26396,8 +26804,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -26462,8 +26869,7 @@
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "pify": {
       "version": "4.0.1",
@@ -29554,7 +29960,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       },
@@ -29562,8 +29967,7 @@
         "is-number": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-          "dev": true
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
         }
       }
     },
@@ -29927,8 +30331,7 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@openzeppelin/contracts-upgradeable-4.4.0": "npm:@openzeppelin/contracts-upgradeable@4.4.0",
     "dotenv": "^10.0.0",
     "hardhat-tracer": "^1.1.0-rc.8",
+    "patch-package": "^6.4.7",
     "synthetix": "2.56.1"
   },
   "devDependencies": {
@@ -77,7 +78,8 @@
     "start": "hardhat node",
     "fork": "hardhat node --fork $npm_config_network",
     "prepare": "npm run build",
-    "addresses": "node scripts/print-addresses.js"
+    "addresses": "node scripts/print-addresses.js",
+    "postinstall": "patch-package"
   },
   "config": {
     "eslintPaths": "test/ deploy/"

--- a/patches/hardhat+2.10.1.patch
+++ b/patches/hardhat+2.10.1.patch
@@ -1,0 +1,441 @@
+diff --git a/node_modules/hardhat/builtin-tasks/node.js b/node_modules/hardhat/builtin-tasks/node.js
+index 3a8cb63..5596a79 100644
+--- a/node_modules/hardhat/builtin-tasks/node.js
++++ b/node_modules/hardhat/builtin-tasks/node.js
+@@ -56,8 +56,9 @@ Private Key: ${privateKey}`;
+ (0, config_env_1.subtask)(task_names_1.TASK_NODE_GET_PROVIDER)
+     .addOptionalParam("forkUrl", undefined, undefined, config_env_1.types.string)
+     .addOptionalParam("forkBlockNumber", undefined, undefined, config_env_1.types.int)
+-    .setAction(async ({ forkBlockNumber: forkBlockNumberParam, forkUrl: forkUrlParam, }, { artifacts, config, network, userConfig }) => {
+-    var _a, _b, _c, _d, _e;
++    .addOptionalParam("forkIgnoreUnknownTxType", undefined, undefined, config_env_1.types.boolean)
++    .setAction(async ({ forkBlockNumber: forkBlockNumberParam, forkUrl: forkUrlParam, forkIgnoreUnknownTxType: forkIgnoreUnknownTxTypeParam, }, { artifacts, config, network, userConfig }) => {
++    var _a, _b, _c, _d, _e, _f;
+     let provider = network.provider;
+     if (network.name !== constants_1.HARDHAT_NETWORK_NAME) {
+         const networkConfig = config.networks[constants_1.HARDHAT_NETWORK_NAME];
+@@ -67,8 +68,10 @@ Private Key: ${privateKey}`;
+     const hardhatNetworkConfig = config.networks[constants_1.HARDHAT_NETWORK_NAME];
+     const forkUrlConfig = (_a = hardhatNetworkConfig.forking) === null || _a === void 0 ? void 0 : _a.url;
+     const forkBlockNumberConfig = (_b = hardhatNetworkConfig.forking) === null || _b === void 0 ? void 0 : _b.blockNumber;
++    const forkIgnoreUnknownTxTypeConfig = (_c = hardhatNetworkConfig.forking) === null || _c === void 0 ? void 0 : _c.ignoreUnknownTxType;
+     const forkUrl = forkUrlParam !== null && forkUrlParam !== void 0 ? forkUrlParam : forkUrlConfig;
+     const forkBlockNumber = forkBlockNumberParam !== null && forkBlockNumberParam !== void 0 ? forkBlockNumberParam : forkBlockNumberConfig;
++    const forkIgnoreUnknownTxType = forkIgnoreUnknownTxTypeParam !== null && forkIgnoreUnknownTxTypeParam !== void 0 ? forkIgnoreUnknownTxTypeParam : forkIgnoreUnknownTxTypeConfig;
+     // we throw an error if the user specified a forkBlockNumber but not a
+     // forkUrl
+     if (forkBlockNumber !== undefined && forkUrl === undefined) {
+@@ -85,16 +88,17 @@ Private Key: ${privateKey}`;
+                     forking: {
+                         jsonRpcUrl: forkUrl,
+                         blockNumber: forkBlockNumber,
++                        ignoreUnknownTxType: forkIgnoreUnknownTxType,
+                     },
+                 },
+             ],
+         });
+     }
+-    const hardhatNetworkUserConfig = (_d = (_c = userConfig.networks) === null || _c === void 0 ? void 0 : _c[constants_1.HARDHAT_NETWORK_NAME]) !== null && _d !== void 0 ? _d : {};
++    const hardhatNetworkUserConfig = (_e = (_d = userConfig.networks) === null || _d === void 0 ? void 0 : _d[constants_1.HARDHAT_NETWORK_NAME]) !== null && _e !== void 0 ? _e : {};
+     // enable logging
+     await provider.request({
+         method: "hardhat_setLoggingEnabled",
+-        params: [(_e = hardhatNetworkUserConfig.loggingEnabled) !== null && _e !== void 0 ? _e : true],
++        params: [(_f = hardhatNetworkUserConfig.loggingEnabled) !== null && _f !== void 0 ? _f : true],
+     });
+     return provider;
+ });
+@@ -142,7 +146,8 @@ Private Key: ${privateKey}`;
+     .addOptionalParam("port", "The port on which to listen for new connections", 8545, config_env_1.types.int)
+     .addOptionalParam("fork", "The URL of the JSON-RPC server to fork from", undefined, config_env_1.types.string)
+     .addOptionalParam("forkBlockNumber", "The block number to fork from", undefined, config_env_1.types.int)
+-    .setAction(async ({ forkBlockNumber, fork: forkUrl, hostname: hostnameParam, port, }, { config, hardhatArguments, network, run }) => {
++    .addOptionalParam("forkIgnoreUnknownTxType", "To ignore unknown transaction types", false, config_env_1.types.boolean)
++    .setAction(async ({ forkBlockNumber, fork: forkUrl, hostname: hostnameParam, port, forkIgnoreUnknownTxType, }, { config, hardhatArguments, network, run }) => {
+     // we throw if the user specified a network argument and it's not hardhat
+     if (network.name !== constants_1.HARDHAT_NETWORK_NAME &&
+         hardhatArguments.network !== undefined) {
+@@ -152,6 +157,7 @@ Private Key: ${privateKey}`;
+         const provider = await run(task_names_1.TASK_NODE_GET_PROVIDER, {
+             forkBlockNumber,
+             forkUrl,
++            forkIgnoreUnknownTxType,
+         });
+         // the default hostname is "127.0.0.1" unless we are inside a docker
+         // container, in that case we use "0.0.0.0"
+@@ -172,6 +178,7 @@ Private Key: ${privateKey}`;
+             hostname,
+             port,
+             provider,
++            forkIgnoreUnknownTxType,
+         });
+         await run(task_names_1.TASK_NODE_SERVER_CREATED, {
+             hostname,
+diff --git a/node_modules/hardhat/internal/hardhat-network/provider/fork/ForkBlockchain.d.ts b/node_modules/hardhat/internal/hardhat-network/provider/fork/ForkBlockchain.d.ts
+index b851c8b..42bedf7 100644
+--- a/node_modules/hardhat/internal/hardhat-network/provider/fork/ForkBlockchain.d.ts
++++ b/node_modules/hardhat/internal/hardhat-network/provider/fork/ForkBlockchain.d.ts
+@@ -11,8 +11,9 @@ import { HardhatBlockchainInterface } from "../types/HardhatBlockchainInterface"
+ export declare class ForkBlockchain extends BlockchainBase implements HardhatBlockchainInterface {
+     private _jsonRpcClient;
+     private _forkBlockNumber;
++    private _forkIgnoreUnknownTxType;
+     private _latestBlockNumber;
+-    constructor(_jsonRpcClient: JsonRpcClient, _forkBlockNumber: BN, common: Common);
++    constructor(_jsonRpcClient: JsonRpcClient, _forkBlockNumber: BN, common: Common, _forkIgnoreUnknownTxType: boolean);
+     getLatestBlockNumber(): BN;
+     getBlock(blockHashOrNumber: Buffer | number | BN): Promise<Block | null>;
+     addBlock(block: Block): Promise<Block>;
+diff --git a/node_modules/hardhat/internal/hardhat-network/provider/fork/ForkBlockchain.js b/node_modules/hardhat/internal/hardhat-network/provider/fork/ForkBlockchain.js
+index 5aa8404..dcc5bc7 100644
+--- a/node_modules/hardhat/internal/hardhat-network/provider/fork/ForkBlockchain.js
++++ b/node_modules/hardhat/internal/hardhat-network/provider/fork/ForkBlockchain.js
+@@ -1,8 +1,12 @@
+ "use strict";
++var __importDefault = (this && this.__importDefault) || function (mod) {
++    return (mod && mod.__esModule) ? mod : { "default": mod };
++};
+ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.ForkBlockchain = void 0;
+ const block_1 = require("@ethereumjs/block");
+ const ethereumjs_util_1 = require("ethereumjs-util");
++const chalk_1 = __importDefault(require("chalk"));
+ const errors_1 = require("../../../core/providers/errors");
+ const BlockchainBase_1 = require("../BlockchainBase");
+ const output_1 = require("../output");
+@@ -13,10 +17,11 @@ const rpcToBlockData_1 = require("./rpcToBlockData");
+ const rpcToTxData_1 = require("./rpcToTxData");
+ /* eslint-disable @nomiclabs/hardhat-internal-rules/only-hardhat-error */
+ class ForkBlockchain extends BlockchainBase_1.BlockchainBase {
+-    constructor(_jsonRpcClient, _forkBlockNumber, common) {
++    constructor(_jsonRpcClient, _forkBlockNumber, common, _forkIgnoreUnknownTxType) {
+         super(common);
+         this._jsonRpcClient = _jsonRpcClient;
+         this._forkBlockNumber = _forkBlockNumber;
++        this._forkIgnoreUnknownTxType = _forkIgnoreUnknownTxType;
+         this._latestBlockNumber = this._forkBlockNumber;
+     }
+     getLatestBlockNumber() {
+@@ -199,7 +204,13 @@ class ForkBlockchain extends BlockchainBase_1.BlockchainBase {
+                 tx = new ReadOnlyValidEIP1559Transaction_1.ReadOnlyValidEIP1559Transaction(new ethereumjs_util_1.Address(transaction.from), (0, rpcToTxData_1.rpcToTxData)(transaction));
+             }
+             else {
+-                throw new errors_1.InternalError(`Unknown transaction type ${transaction.type.toString()}`);
++                if (this._forkIgnoreUnknownTxType) {
++                    console.log(chalk_1.default.yellow(`Ignored a tx with unknown type ${transaction.type}`));
++                    continue;
++                }
++                else {
++                    throw new errors_1.InternalError(`Unknown transaction type ${transaction.type.toString()}, set --fork-ignore-unknown-tx-type true to ignore`);
++                }
+             }
+             block.transactions.push(tx);
+         }
+diff --git a/node_modules/hardhat/internal/hardhat-network/provider/node-types.d.ts b/node_modules/hardhat/internal/hardhat-network/provider/node-types.d.ts
+index 1dbf710..6361315 100644
+--- a/node_modules/hardhat/internal/hardhat-network/provider/node-types.d.ts
++++ b/node_modules/hardhat/internal/hardhat-network/provider/node-types.d.ts
+@@ -32,6 +32,7 @@ export interface ForkConfig {
+     httpHeaders?: {
+         [name: string]: string;
+     };
++    ignoreUnknownTxType?: boolean;
+ }
+ export interface ForkedNodeConfig extends CommonConfig {
+     forkConfig: ForkConfig;
+diff --git a/node_modules/hardhat/internal/hardhat-network/provider/node.js b/node_modules/hardhat/internal/hardhat-network/provider/node.js
+index f60f762..06dcebd 100644
+--- a/node_modules/hardhat/internal/hardhat-network/provider/node.js
++++ b/node_modules/hardhat/internal/hardhat-network/provider/node.js
+@@ -128,7 +128,7 @@ class HardhatNode extends events_1.default {
+         const hardfork = (0, hardforks_1.getHardforkName)(config.hardfork);
+         let forkClient;
+         if ((0, node_types_1.isForkedNodeConfig)(config)) {
+-            const { forkClient: _forkClient, forkBlockNumber, forkBlockTimestamp, } = await (0, makeForkClient_1.makeForkClient)(config.forkConfig, config.forkCachePath);
++            const { forkClient: _forkClient, forkBlockNumber, forkBlockTimestamp, forkIgnoreUnknownTxType, } = await (0, makeForkClient_1.makeForkClient)(config.forkConfig, config.forkCachePath);
+             forkClient = _forkClient;
+             common = await (0, makeForkCommon_1.makeForkCommon)(config);
+             forkNetworkId = forkClient.getNetworkId();
+@@ -137,7 +137,7 @@ class HardhatNode extends events_1.default {
+             const forkStateManager = new ForkStateManager_1.ForkStateManager(forkClient, forkBlockNumber);
+             await forkStateManager.initializeGenesisAccounts(genesisAccounts);
+             stateManager = forkStateManager;
+-            blockchain = new ForkBlockchain_1.ForkBlockchain(forkClient, forkBlockNumber, common);
++            blockchain = new ForkBlockchain_1.ForkBlockchain(forkClient, forkBlockNumber, common, forkIgnoreUnknownTxType);
+             initialBlockTimeOffset = new ethereumjs_util_1.BN((0, date_1.getDifferenceInSeconds)(new Date(forkBlockTimestamp), new Date()));
+             // If the hardfork is London or later we need a base fee per gas for the
+             // first local block. If initialBaseFeePerGas config was provided we use
+diff --git a/node_modules/hardhat/internal/hardhat-network/provider/utils/makeForkClient.d.ts b/node_modules/hardhat/internal/hardhat-network/provider/utils/makeForkClient.d.ts
+index f79dccb..1f3cb03 100644
+--- a/node_modules/hardhat/internal/hardhat-network/provider/utils/makeForkClient.d.ts
++++ b/node_modules/hardhat/internal/hardhat-network/provider/utils/makeForkClient.d.ts
+@@ -5,5 +5,6 @@ export declare function makeForkClient(forkConfig: ForkConfig, forkCachePath?: s
+     forkClient: JsonRpcClient;
+     forkBlockNumber: BN;
+     forkBlockTimestamp: number;
++    forkIgnoreUnknownTxType: boolean;
+ }>;
+ //# sourceMappingURL=makeForkClient.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/hardhat/internal/hardhat-network/provider/utils/makeForkClient.js b/node_modules/hardhat/internal/hardhat-network/provider/utils/makeForkClient.js
+index dd37a51..697670d 100644
+--- a/node_modules/hardhat/internal/hardhat-network/provider/utils/makeForkClient.js
++++ b/node_modules/hardhat/internal/hardhat-network/provider/utils/makeForkClient.js
+@@ -18,6 +18,7 @@ const reorgs_protection_1 = require("./reorgs-protection");
+ //  anymore, so this really should be revisited.
+ const FORK_HTTP_TIMEOUT = 35000;
+ async function makeForkClient(forkConfig, forkCachePath) {
++    var _a;
+     const provider = new http_1.HttpProvider(forkConfig.jsonRpcUrl, constants_1.HARDHAT_NETWORK_NAME, forkConfig.httpHeaders, FORK_HTTP_TIMEOUT);
+     const networkId = await getNetworkId(provider);
+     const actualMaxReorg = (0, reorgs_protection_1.getLargestPossibleReorg)(networkId);
+@@ -43,11 +44,17 @@ Please use block number ${lastSafeBlock} or wait for the block to get ${required
+     }
+     const block = await getBlockByNumber(provider, forkBlockNumber);
+     const forkBlockTimestamp = (0, base_types_1.rpcQuantityToNumber)(block.timestamp) * 1000;
++    const forkIgnoreUnknownTxType = (_a = forkConfig.ignoreUnknownTxType) !== null && _a !== void 0 ? _a : false;
+     const cacheToDiskEnabled = forkConfig.blockNumber !== undefined &&
+         forkCachePath !== undefined &&
+         actualMaxReorg !== undefined;
+     const forkClient = new client_1.JsonRpcClient(provider, networkId, latestBlock, maxReorg, cacheToDiskEnabled ? forkCachePath : undefined);
+-    return { forkClient, forkBlockNumber, forkBlockTimestamp };
++    return {
++        forkClient,
++        forkBlockNumber,
++        forkBlockTimestamp,
++        forkIgnoreUnknownTxType,
++    };
+ }
+ exports.makeForkClient = makeForkClient;
+ async function getBlockByNumber(provider, blockNumber) {
+diff --git a/node_modules/hardhat/src/builtin-tasks/node.ts b/node_modules/hardhat/src/builtin-tasks/node.ts
+index 5f608c2..a5d3613 100644
+--- a/node_modules/hardhat/src/builtin-tasks/node.ts
++++ b/node_modules/hardhat/src/builtin-tasks/node.ts
+@@ -97,14 +97,22 @@ Private Key: ${privateKey}`;
+ subtask(TASK_NODE_GET_PROVIDER)
+   .addOptionalParam("forkUrl", undefined, undefined, types.string)
+   .addOptionalParam("forkBlockNumber", undefined, undefined, types.int)
++  .addOptionalParam(
++    "forkIgnoreUnknownTxType",
++    undefined,
++    undefined,
++    types.boolean
++  )
+   .setAction(
+     async (
+       {
+         forkBlockNumber: forkBlockNumberParam,
+         forkUrl: forkUrlParam,
++        forkIgnoreUnknownTxType: forkIgnoreUnknownTxTypeParam,
+       }: {
+         forkBlockNumber?: number;
+         forkUrl?: string;
++        forkIgnoreUnknownTxType?: boolean;
+       },
+       { artifacts, config, network, userConfig }
+     ): Promise<EthereumProvider> => {
+@@ -126,9 +134,13 @@ subtask(TASK_NODE_GET_PROVIDER)
+ 
+       const forkUrlConfig = hardhatNetworkConfig.forking?.url;
+       const forkBlockNumberConfig = hardhatNetworkConfig.forking?.blockNumber;
++      const forkIgnoreUnknownTxTypeConfig =
++        hardhatNetworkConfig.forking?.ignoreUnknownTxType;
+ 
+       const forkUrl = forkUrlParam ?? forkUrlConfig;
+       const forkBlockNumber = forkBlockNumberParam ?? forkBlockNumberConfig;
++      const forkIgnoreUnknownTxType =
++        forkIgnoreUnknownTxTypeParam ?? forkIgnoreUnknownTxTypeConfig;
+ 
+       // we throw an error if the user specified a forkBlockNumber but not a
+       // forkUrl
+@@ -151,6 +163,7 @@ subtask(TASK_NODE_GET_PROVIDER)
+               forking: {
+                 jsonRpcUrl: forkUrl,
+                 blockNumber: forkBlockNumber,
++                ignoreUnknownTxType: forkIgnoreUnknownTxType,
+               },
+             },
+           ],
+@@ -275,6 +288,12 @@ task(TASK_NODE, "Starts a JSON-RPC server on top of Hardhat Network")
+     undefined,
+     types.int
+   )
++  .addOptionalParam(
++    "forkIgnoreUnknownTxType",
++    "To ignore unknown transaction types",
++    false,
++    types.boolean
++  )
+   .setAction(
+     async (
+       {
+@@ -282,11 +301,13 @@ task(TASK_NODE, "Starts a JSON-RPC server on top of Hardhat Network")
+         fork: forkUrl,
+         hostname: hostnameParam,
+         port,
++        forkIgnoreUnknownTxType,
+       }: {
+         forkBlockNumber?: number;
+         fork?: string;
+         hostname?: string;
+         port: number;
++        forkIgnoreUnknownTxType?: boolean;
+       },
+       { config, hardhatArguments, network, run }
+     ) => {
+@@ -304,6 +325,7 @@ task(TASK_NODE, "Starts a JSON-RPC server on top of Hardhat Network")
+         const provider: EthereumProvider = await run(TASK_NODE_GET_PROVIDER, {
+           forkBlockNumber,
+           forkUrl,
++          forkIgnoreUnknownTxType,
+         });
+ 
+         // the default hostname is "127.0.0.1" unless we are inside a docker
+@@ -324,6 +346,7 @@ task(TASK_NODE, "Starts a JSON-RPC server on top of Hardhat Network")
+           hostname,
+           port,
+           provider,
++          forkIgnoreUnknownTxType,
+         });
+ 
+         await run(TASK_NODE_SERVER_CREATED, {
+diff --git a/node_modules/hardhat/src/internal/hardhat-network/provider/fork/ForkBlockchain.ts b/node_modules/hardhat/src/internal/hardhat-network/provider/fork/ForkBlockchain.ts
+index 1f04ad1..c5e28a7 100644
+--- a/node_modules/hardhat/src/internal/hardhat-network/provider/fork/ForkBlockchain.ts
++++ b/node_modules/hardhat/src/internal/hardhat-network/provider/fork/ForkBlockchain.ts
+@@ -4,6 +4,7 @@ import { TypedTransaction } from "@ethereumjs/tx";
+ import { Address, BN } from "ethereumjs-util";
+ 
+ import { FeeMarketEIP1559TxData } from "@ethereumjs/tx/dist/types";
++import chalk from "chalk";
+ import { RpcBlockWithTransactions } from "../../../core/jsonrpc/types/output/block";
+ import { RpcTransactionReceipt } from "../../../core/jsonrpc/types/output/receipt";
+ import { RpcTransaction } from "../../../core/jsonrpc/types/output/transaction";
+@@ -38,7 +39,8 @@ export class ForkBlockchain
+   constructor(
+     private _jsonRpcClient: JsonRpcClient,
+     private _forkBlockNumber: BN,
+-    common: Common
++    common: Common,
++    private _forkIgnoreUnknownTxType: boolean
+   ) {
+     super(common);
+   }
+@@ -295,9 +297,16 @@ export class ForkBlockchain
+           rpcToTxData(transaction) as FeeMarketEIP1559TxData
+         );
+       } else {
+-        throw new InternalError(
+-          `Unknown transaction type ${transaction.type.toString()}`
+-        );
++        if (this._forkIgnoreUnknownTxType) {
++          console.log(
++            chalk.yellow(`Ignored a tx with unknown type ${transaction.type}`)
++          );
++          continue;
++        } else {
++          throw new InternalError(
++            `Unknown transaction type ${transaction.type.toString()}, set --fork-ignore-unknown-tx-type true to ignore`
++          );
++        }
+       }
+ 
+       block.transactions.push(tx);
+diff --git a/node_modules/hardhat/src/internal/hardhat-network/provider/node-types.ts b/node_modules/hardhat/src/internal/hardhat-network/provider/node-types.ts
+index 5181177..740ee0b 100644
+--- a/node_modules/hardhat/src/internal/hardhat-network/provider/node-types.ts
++++ b/node_modules/hardhat/src/internal/hardhat-network/provider/node-types.ts
+@@ -40,6 +40,7 @@ export interface ForkConfig {
+   jsonRpcUrl: string;
+   blockNumber?: number;
+   httpHeaders?: { [name: string]: string };
++  ignoreUnknownTxType?: boolean;
+ }
+ 
+ export interface ForkedNodeConfig extends CommonConfig {
+diff --git a/node_modules/hardhat/src/internal/hardhat-network/provider/node.ts b/node_modules/hardhat/src/internal/hardhat-network/provider/node.ts
+index 172cfc3..0b711bf 100644
+--- a/node_modules/hardhat/src/internal/hardhat-network/provider/node.ts
++++ b/node_modules/hardhat/src/internal/hardhat-network/provider/node.ts
+@@ -158,6 +158,7 @@ export class HardhatNode extends EventEmitter {
+         forkClient: _forkClient,
+         forkBlockNumber,
+         forkBlockTimestamp,
++        forkIgnoreUnknownTxType,
+       } = await makeForkClient(config.forkConfig, config.forkCachePath);
+       forkClient = _forkClient;
+       common = await makeForkCommon(config);
+@@ -178,7 +179,12 @@ export class HardhatNode extends EventEmitter {
+       await forkStateManager.initializeGenesisAccounts(genesisAccounts);
+       stateManager = forkStateManager;
+ 
+-      blockchain = new ForkBlockchain(forkClient, forkBlockNumber, common);
++      blockchain = new ForkBlockchain(
++        forkClient,
++        forkBlockNumber,
++        common,
++        forkIgnoreUnknownTxType
++      );
+ 
+       initialBlockTimeOffset = new BN(
+         getDifferenceInSeconds(new Date(forkBlockTimestamp), new Date())
+diff --git a/node_modules/hardhat/src/internal/hardhat-network/provider/utils/makeForkClient.ts b/node_modules/hardhat/src/internal/hardhat-network/provider/utils/makeForkClient.ts
+index 51a8c6f..6d1762b 100644
+--- a/node_modules/hardhat/src/internal/hardhat-network/provider/utils/makeForkClient.ts
++++ b/node_modules/hardhat/src/internal/hardhat-network/provider/utils/makeForkClient.ts
+@@ -30,6 +30,7 @@ export async function makeForkClient(
+   forkClient: JsonRpcClient;
+   forkBlockNumber: BN;
+   forkBlockTimestamp: number;
++  forkIgnoreUnknownTxType: boolean;
+ }> {
+   const provider = new HttpProvider(
+     forkConfig.jsonRpcUrl,
+@@ -78,6 +79,8 @@ Please use block number ${lastSafeBlock} or wait for the block to get ${
+ 
+   const forkBlockTimestamp = rpcQuantityToNumber(block.timestamp) * 1000;
+ 
++  const forkIgnoreUnknownTxType = forkConfig.ignoreUnknownTxType ?? false;
++
+   const cacheToDiskEnabled =
+     forkConfig.blockNumber !== undefined &&
+     forkCachePath !== undefined &&
+@@ -91,7 +94,12 @@ Please use block number ${lastSafeBlock} or wait for the block to get ${
+     cacheToDiskEnabled ? forkCachePath : undefined
+   );
+ 
+-  return { forkClient, forkBlockNumber, forkBlockTimestamp };
++  return {
++    forkClient,
++    forkBlockNumber,
++    forkBlockTimestamp,
++    forkIgnoreUnknownTxType,
++  };
+ }
+ 
+ async function getBlockByNumber(
+diff --git a/node_modules/hardhat/src/types/config.ts b/node_modules/hardhat/src/types/config.ts
+index bb53022..3944364 100644
+--- a/node_modules/hardhat/src/types/config.ts
++++ b/node_modules/hardhat/src/types/config.ts
+@@ -178,6 +178,7 @@ export interface HardhatNetworkForkingConfig {
+   url: string;
+   blockNumber?: number;
+   httpHeaders: { [name: string]: string };
++  ignoreUnknownTxType?: boolean;
+ }
+ 
+ export interface HttpNetworkConfig {
+diff --git a/node_modules/hardhat/types/config.d.ts b/node_modules/hardhat/types/config.d.ts
+index b5cd480..2626393 100644
+--- a/node_modules/hardhat/types/config.d.ts
++++ b/node_modules/hardhat/types/config.d.ts
+@@ -129,6 +129,7 @@ export interface HardhatNetworkForkingConfig {
+     httpHeaders: {
+         [name: string]: string;
+     };
++    ignoreUnknownTxType?: boolean;
+ }
+ export interface HttpNetworkConfig {
+     chainId?: number;


### PR DESCRIPTION
Currently, forking arbitrum is not possible on hardhat 2.10.2.
This commit adds a patch from https://github.com/NomicFoundation/hardhat/issues/2995 

https://gist.github.com/gzeoneth/195cb16f00eaa32fa868e6c0192616c1

After running `npm i --legacy-peer-deps`
Arbitrum can be forked with below command.
```
npx hardhat node --fork arbitrum_mainnet --fork-ignore-unknown-tx-type true
```

Once hardhat fixes this issue this patch should be removed.