### PR TITLE
Specify deploy tags for each test

### DIFF
--- a/deploy/hardhat/006_deploy_Swap.ts
+++ b/deploy/hardhat/006_deploy_Swap.ts
@@ -31,4 +31,4 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 }
 export default func
 func.tags = ["Swap"]
-func.dependencies = ["AmplificationUtils", "SwapUtils"]
+func.dependencies = ["AmplificationUtils", "SwapUtils", "LPToken"]

--- a/deploy/hardhat/450_deploy_PermissionlessSwaps.ts
+++ b/deploy/hardhat/450_deploy_PermissionlessSwaps.ts
@@ -109,4 +109,13 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 }
 export default func
 func.tags = ["PermissionlessSwaps"]
+func.dependencies = [
+  "SUSDMetaPoolDeposit",
+  "LPToken",
+  "SwapUtils",
+  "MetaSwapUtils",
+  "MasterRegistry",
+  "PoolRegistry",
+  "AmplificationUtils",
+]
 // func.skip = async (env) => (await env.getChainId()) == CHAIN_ID.MAINNET

--- a/test/allowlist.ts
+++ b/test/allowlist.ts
@@ -23,7 +23,7 @@ describe("Allowlist", () => {
 
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
-      await deployments.fixture() // ensure you start from a fresh deployments
+      await deployments.fixture([]) // ensure you start from a fresh deployments
 
       signers = await ethers.getSigners()
       malActor = signers[10]

--- a/test/flashloan.ts
+++ b/test/flashloan.ts
@@ -5,6 +5,7 @@ import { deployments } from "hardhat"
 import {
   FlashLoanBorrowerExample,
   GenericERC20,
+  GenericERC20__factory,
   LPToken,
   SwapFlashLoan,
 } from "../build/typechain/"
@@ -48,7 +49,7 @@ describe("Swap Flashloan", () => {
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
       const { get } = deployments
-      await deployments.fixture() // ensure you start from a fresh deployments
+      await deployments.fixture(["SUSDMetaPoolTokens"]) // ensure you start from a fresh deployments
 
       TOKENS.length = 0
       signers = await ethers.getSigners()
@@ -60,13 +61,14 @@ describe("Swap Flashloan", () => {
       user1Address = await user1.getAddress()
       user2Address = await user2.getAddress()
 
-      const erc20Factory = await ethers.getContractFactory("GenericERC20")
+      const erc20Factory: GenericERC20__factory =
+        await ethers.getContractFactory("GenericERC20")
 
       // Deploy dummy tokens
-      DAI = await ethers.getContract("DAI")
-      USDC = await ethers.getContract("USDC")
-      USDT = await ethers.getContract("USDT")
-      SUSD = await ethers.getContract("SUSD")
+      DAI = await erc20Factory.deploy("DAI", "DAI", "18")
+      USDC = await erc20Factory.deploy("USDC", "USDC", "6")
+      USDT = await erc20Factory.deploy("USDT", "USDT", "6")
+      SUSD = await erc20Factory.deploy("SUSD", "SUSD", "18")
 
       TOKENS.push(DAI, USDC, USDT, SUSD)
 

--- a/test/metaPoolAdminFees_Inflated_BP_VP.ts
+++ b/test/metaPoolAdminFees_Inflated_BP_VP.ts
@@ -54,8 +54,7 @@ describe("Meta-Swap with inflated baseVirtualPrice and 50% admin fees", async ()
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
       const { get } = deployments
-      await deployments.fixture(["Swap", "USDPool"]) // ensure you start from a fresh deployments
-
+      await deployments.fixture(["Swap", "USDPool", "MetaSwapUtils"])
       signers = await ethers.getSigners()
       owner = signers[0]
       user1 = signers[1]

--- a/test/metaPoolHighAdminFees_Inflated_BP_VP.ts
+++ b/test/metaPoolHighAdminFees_Inflated_BP_VP.ts
@@ -54,7 +54,7 @@ describe("Meta-Swap with inflated baseVirtualPrice and 99% admin fees", async ()
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
       const { get } = deployments
-      await deployments.fixture() // ensure you start from a fresh deployments
+      await deployments.fixture(["Swap", "USDPool", "MetaSwapUtils"])
 
       signers = await ethers.getSigners()
       owner = signers[0]

--- a/test/metaPool_Inflated_BP_VP.ts
+++ b/test/metaPool_Inflated_BP_VP.ts
@@ -54,8 +54,7 @@ describe("Meta-Swap with inflated baseVirtualPrice", async () => {
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
       const { get } = deployments
-      await deployments.fixture(["Swap", "USDPool"]) // ensure you start from a fresh deployments
-
+      await deployments.fixture(["Swap", "USDPool", "MetaSwapUtils"])
       signers = await ethers.getSigners()
       owner = signers[0]
       user1 = signers[1]

--- a/test/metaSwap.ts
+++ b/test/metaSwap.ts
@@ -47,7 +47,7 @@ describe("Meta-Swap", async () => {
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
       const { get } = deployments
-      await deployments.fixture() // ensure you start from a fresh deployments
+      await deployments.fixture(["Swap", "USDPool", "MetaSwapUtils"])
 
       signers = await ethers.getSigners()
       owner = signers[0]

--- a/test/metaSwapDecimals.ts
+++ b/test/metaSwapDecimals.ts
@@ -54,7 +54,7 @@ describe("Meta-Swap", async () => {
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
       const { get } = deployments
-      await deployments.fixture() // ensure you start from a fresh deployments
+      await deployments.fixture(["Swap", "USDPool", "MetaSwapUtils"]) // ensure you start from a fresh deployments
 
       signers = await ethers.getSigners()
       owner = signers[0]

--- a/test/metaSwapDeposit.ts
+++ b/test/metaSwapDeposit.ts
@@ -50,7 +50,7 @@ describe("Meta-Swap Deposit Contract", async () => {
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
       const { get } = deployments
-      await deployments.fixture() // ensure you start from a fresh deployments
+      await deployments.fixture(["Swap", "USDPool", "MetaSwapUtils"]) // ensure you start from a fresh deployments
 
       signers = await ethers.getSigners()
       owner = signers[0]

--- a/test/permissionless/permissionlessDeployer.ts
+++ b/test/permissionless/permissionlessDeployer.ts
@@ -84,7 +84,7 @@ describe("PermissionlessDeployer", async () => {
 
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
-      await deployments.fixture() // ensure you start from a fresh deployments
+      await deployments.fixture(["D4PoolTokens", "PermissionlessSwaps"]) // ensure you start from a fresh deployments
 
       signers = await ethers.getSigners()
       deployer = signers[0]

--- a/test/permissionless/permissionlessMetaSwapFlashLoan.ts
+++ b/test/permissionless/permissionlessMetaSwapFlashLoan.ts
@@ -52,7 +52,7 @@ describe("PermissionlessMetaSwapFlashLoan with inflated baseVirtualPrice and 50%
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
       const { get } = deployments
-      await deployments.fixture() // ensure you start from a fresh deployments
+      await deployments.fixture(["USDPool", "MetaSwapUtils", "MasterRegistry"]) // ensure you start from a fresh deployments
 
       signers = await ethers.getSigners()
       owner = signers[0]

--- a/test/permissionless/permissionlessSwapFlashLoan.ts
+++ b/test/permissionless/permissionlessSwapFlashLoan.ts
@@ -3,6 +3,7 @@ import { BigNumber, Signer } from "ethers"
 import { deployments } from "hardhat"
 import {
   GenericERC20,
+  GenericERC20__factory,
   LPToken,
   MasterRegistry,
   Swap,
@@ -56,7 +57,7 @@ describe("PermissionlessSwapFlashLoan with 4 tokens", () => {
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
       const { get, deploy } = deployments
-      await deployments.fixture() // ensure you start from a fresh deployments
+      await deployments.fixture(["Swap", "MasterRegistry"]) // ensure you start from a fresh deployments
 
       TOKENS.length = 0
       signers = await ethers.getSigners()
@@ -68,17 +69,13 @@ describe("PermissionlessSwapFlashLoan with 4 tokens", () => {
       user1Address = await user1.getAddress()
       user2Address = await user2.getAddress()
 
-      await deploy("SUSD", {
-        from: ownerAddress,
-        contract: "GenericERC20",
-        args: ["SUSD", "Synthetix USD", "18"],
-        skipIfAlreadyDeployed: true,
-      })
+      const erc20Factory: GenericERC20__factory =
+        await ethers.getContractFactory("GenericERC20")
 
-      DAI = await ethers.getContract("DAI")
-      USDC = await ethers.getContract("USDC")
-      USDT = await ethers.getContract("USDT")
-      SUSD = await ethers.getContract("SUSD")
+      DAI = await erc20Factory.deploy("DAI", "DAI", "18")
+      USDC = await erc20Factory.deploy("USDC", "USDC", "6")
+      USDT = await erc20Factory.deploy("USDT", "USDT", "6")
+      SUSD = await erc20Factory.deploy("SUSD", "SUSD", "18")
 
       TOKENS.push(DAI, USDC, USDT, SUSD)
 

--- a/test/retroactiveVesting.ts
+++ b/test/retroactiveVesting.ts
@@ -48,7 +48,7 @@ describe("Retroactive Vesting", () => {
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
       const { deploy } = deployments
-      await deployments.fixture() // ensure you start from a fresh deployments
+      await deployments.fixture([]) // ensure you start from a fresh deployments
 
       signers = await ethers.getSigners()
       deployer = signers[0]

--- a/test/rewards/simpleRewarder.ts
+++ b/test/rewards/simpleRewarder.ts
@@ -12,6 +12,7 @@ import {
   BIG_NUMBER_1E18,
   BIG_NUMBER_ZERO,
   getCurrentBlockTimestamp,
+  increaseTimestamp,
   MAX_UINT256,
   setTimestamp,
   ZERO_ADDRESS,
@@ -372,25 +373,26 @@ describe("SimpleRewarder", async () => {
       await miniChef.set(0, 1, simpleRewarder.address, true)
 
       await miniChef.connect(farmer).harvest(0, farmerAddress)
-      await setTimestamp((await getCurrentBlockTimestamp()) + 1000)
-
       expect(await usdv2LpToken.balanceOf(farmerAddress)).to.eq(
         BIG_NUMBER_1E18.mul(5),
       )
-      expect(await rewardToken1.balanceOf(farmerAddress)).to.eq(
+      expect(await rewardToken1.balanceOf(farmerAddress)).to.closeTo(
         BIG_NUMBER_1E18.mul(5),
+        BIG_NUMBER_1E18,
       )
       expect(await rewardToken2.balanceOf(farmerAddress)).to.eq(0)
+
+      await increaseTimestamp(1000)
+
       await miniChef
         .connect(farmer)
         .withdrawAndHarvest(0, BIG_NUMBER_1E18, farmerAddress)
       expect(await usdv2LpToken.balanceOf(farmerAddress)).to.eq(
         BIG_NUMBER_1E18.mul(6),
       )
-      expect(await rewardToken1.balanceOf(farmerAddress)).to.satisfy(
-        (balance: BigNumber) =>
-          balance.eq(BIG_NUMBER_1E18.mul(1006)) ||
-          balance.eq(BIG_NUMBER_1E18.mul(1007)),
+      expect(await rewardToken1.balanceOf(farmerAddress)).to.closeTo(
+        BIG_NUMBER_1E18.mul(1006),
+        BIG_NUMBER_1E18,
       )
       expect(await rewardToken2.balanceOf(farmerAddress)).to.eq(
         BIG_NUMBER_1E18.mul(2002),

--- a/test/stakeableTokenWrapper.ts
+++ b/test/stakeableTokenWrapper.ts
@@ -35,7 +35,7 @@ describe("StakeableTokenWrapper", () => {
 
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
-      await deployments.fixture() // ensure you start from a fresh deployments
+      await deployments.fixture([]) // ensure you start from a fresh deployments
 
       signers = await ethers.getSigners()
       const erc20Factory = await ethers.getContractFactory("GenericERC20")

--- a/test/swap4tokens.ts
+++ b/test/swap4tokens.ts
@@ -1,7 +1,12 @@
 import chai from "chai"
 import { BigNumber, Signer } from "ethers"
 import { deployments } from "hardhat"
-import { GenericERC20, LPToken, Swap } from "../build/typechain/"
+import {
+  GenericERC20,
+  GenericERC20__factory,
+  LPToken,
+  Swap,
+} from "../build/typechain/"
 import {
   asyncForEach,
   getCurrentBlockTimestamp,
@@ -50,7 +55,7 @@ describe("Swap with 4 tokens", () => {
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
       const { get, deploy } = deployments
-      await deployments.fixture() // ensure you start from a fresh deployments
+      await deployments.fixture(["Swap"]) // ensure you start from a fresh deployments
 
       TOKENS.length = 0
       signers = await ethers.getSigners()
@@ -62,17 +67,13 @@ describe("Swap with 4 tokens", () => {
       user1Address = await user1.getAddress()
       user2Address = await user2.getAddress()
 
-      await deploy("SUSD", {
-        from: ownerAddress,
-        contract: "GenericERC20",
-        args: ["SUSD", "Synthetix USD", "18"],
-        skipIfAlreadyDeployed: true,
-      })
+      const erc20Factory: GenericERC20__factory =
+        await ethers.getContractFactory("GenericERC20")
 
-      DAI = await ethers.getContract("DAI")
-      USDC = await ethers.getContract("USDC")
-      USDT = await ethers.getContract("USDT")
-      SUSD = await ethers.getContract("SUSD")
+      DAI = await erc20Factory.deploy("DAI", "DAI", "18")
+      USDC = await erc20Factory.deploy("USDC", "USDC", "6")
+      USDT = await erc20Factory.deploy("USDT", "USDT", "6")
+      SUSD = await erc20Factory.deploy("SUSD", "SUSD", "18")
 
       TOKENS.push(DAI, USDC, USDT, SUSD)
 

--- a/test/swapCalculator_forking.ts
+++ b/test/swapCalculator_forking.ts
@@ -17,27 +17,23 @@ describe("SwapCalculator (D4 pool on forked mainnet) [ @skip-on-coverage ]", asy
   let usdv2: Swap
   let d4: Swap
 
-  before(async () => {
-    await network.provider.request({
-      method: "hardhat_reset",
-      params: [
-        {
-          forking: {
-            jsonRpcUrl:
-              ALCHEMY_BASE_URL[CHAIN_ID.MAINNET] + process.env.ALCHEMY_API_KEY,
-            blockNumber: 14391465,
-            ignoreUnknownTxType: true,
-          },
-        },
-      ],
-    })
-
-    // await setTimestamp(16473514010)
-  })
-
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
-      await deployments.fixture([], { keepExistingDeployments: true }) // start from empty state
+      // Fork mainnet at block 14391465
+      await network.provider.request({
+        method: "hardhat_reset",
+        params: [
+          {
+            forking: {
+              jsonRpcUrl:
+                ALCHEMY_BASE_URL[CHAIN_ID.MAINNET] +
+                process.env.ALCHEMY_API_KEY,
+              blockNumber: 14391465,
+              ignoreUnknownTxType: true,
+            },
+          },
+        ],
+      })
 
       signers = await ethers.getSigners()
       owner = signers[0]

--- a/test/swapDeployer.ts
+++ b/test/swapDeployer.ts
@@ -60,7 +60,7 @@ describe("Swap Deployer", () => {
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
       const { get, deploy } = deployments
-      await deployments.fixture() // ensure you start from a fresh deployments
+      await deployments.fixture(["Swap", "USDPool", "SwapDeployer"]) // ensure you start from a fresh deployments
 
       TOKENS.length = 0
       signers = await ethers.getSigners()

--- a/test/swapInitialize.ts
+++ b/test/swapInitialize.ts
@@ -6,7 +6,7 @@ import { ZERO_ADDRESS } from "./testUtils"
 
 const { expect } = chai
 
-describe("Swap", () => {
+describe("Swap Initialize", () => {
   let signers: Array<Signer>
   let swap: Swap
   let firstToken: GenericERC20
@@ -22,7 +22,7 @@ describe("Swap", () => {
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
       const { get } = deployments
-      await deployments.fixture() // ensure you start from a fresh deployments
+      await deployments.fixture(["Swap"]) // ensure you start from a fresh deployments
 
       signers = await ethers.getSigners()
       owner = signers[0]

--- a/test/token.ts
+++ b/test/token.ts
@@ -37,7 +37,7 @@ describe("Token", () => {
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
       const { deploy, deterministic } = deployments
-      await deployments.fixture() // ensure you start from a fresh deployments
+      await deployments.fixture([]) // ensure you start from a fresh deployments
 
       signers = await ethers.getSigners()
       deployer = signers[0]

--- a/test/tokenomics/votingEscrow.ts
+++ b/test/tokenomics/votingEscrow.ts
@@ -378,8 +378,9 @@ describe("VotingEscrow", () => {
 
       // Increase unlock time
       await veSDL.increase_unlock_time(LOCK_START_TIMESTAMP + MAXTIME)
-      expect(await veSDL["balanceOf(address)"](deployerAddress)).to.eq(
-        "14999999682902080113010136",
+      expect(await veSDL["balanceOf(address)"](deployerAddress)).to.closeTo(
+        BIG_NUMBER_1E18.mul(15_000_000),
+        BIG_NUMBER_1E18,
       )
 
       const locked = await veSDL.locked(deployerAddress)

--- a/test/vesting.ts
+++ b/test/vesting.ts
@@ -31,7 +31,7 @@ describe("Vesting", () => {
   const setupTest = deployments.createFixture(
     async ({ deployments, ethers }) => {
       const { deploy } = deployments
-      await deployments.fixture() // ensure you start from a fresh deployments
+      await deployments.fixture([]) // ensure you start from a fresh deployments
 
       signers = await ethers.getSigners()
       deployer = signers[0]


### PR DESCRIPTION
This will prevent re-deploying the entire deploy fixture if its not necessary.