### PR TITLE
Add a simple script for giving some tokens to hardhat account in anvil fork

### DIFF
--- a/forge-script/GetRich.s.sol
+++ b/forge-script/GetRich.s.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.17;
 import "./ScriptWithConstants.s.sol";
 import "forge-std/Test.sol";
 
-contract GetRich is Test, ScriptWithConstants {
+contract GetRichScript is Test, ScriptWithConstants {
     address USDC;
     address DAI;
 
@@ -13,11 +13,13 @@ contract GetRich is Test, ScriptWithConstants {
     function setUp() public override {
         super.setUp();
 
+        // Get the addresses of the tokens in this network
         USDC = getDeploymentAddress("USDC");
         DAI = getDeploymentAddress("DAI");
     }
 
     function run() public {
+        // Use foundry's cheatcode to give us some tokens
         deal(USDC, hardhatAccount0, 1e6 * 10000);
         deal(DAI, hardhatAccount0, 1e18 * 10000);
     }

--- a/forge-script/GetRich.s.sol
+++ b/forge-script/GetRich.s.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "./ScriptWithConstants.s.sol";
+import "forge-std/Test.sol";
+
+contract GetRich is Test, ScriptWithConstants {
+    address USDC;
+    address DAI;
+
+    address hardhatAccount0 = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
+
+    function setUp() public override {
+        super.setUp();
+
+        USDC = getDeploymentAddress("USDC");
+        DAI = getDeploymentAddress("DAI");
+    }
+
+    function run() public {
+        deal(USDC, hardhatAccount0, 1e6 * 10000);
+        deal(DAI, hardhatAccount0, 1e18 * 10000);
+    }
+}


### PR DESCRIPTION
First, anvil should be ran with a fork flag with a valid RPC url.
```bash
anvil -f $RPC_URL
```

Then you can run this script against localhost
```bash
forge script --rpc-url http://localhost:8545 GetRichScript -vvvv
```

You can confirm the default hardhat account `0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266` now has some ERC20s to play around.