### PR TITLE
Use specific factory type to ensure formatting calldata is correct

### DIFF
--- a/deploy/mainnet/672_deploy_x_chain_gauges.ts
+++ b/deploy/mainnet/672_deploy_x_chain_gauges.ts
@@ -66,21 +66,21 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   // Get RootGaugeFactory contract and interface
   const rgf: RootGaugeFactory = await ethers.getContract("RootGaugeFactory")
-  const callData = rgf.interface.encodeFunctionData("deploy_gauge", [
+  let callData = rgf.interface.encodeFunctionData("deploy_gauge", [
     deployGaugeData.chainId,
     deployGaugeData.salt,
     deployGaugeData.gaugeName,
   ])
-
+  callData = ethers.utils.defaultAbiCoder.encode(
+    ["address", "bytes"],
+    [rgf.address, callData],
+  )
   // Call anyExecute from impersonated executor account (owned by AnyCall)
   // Then confirm new gauge was deployed via event emitted by RootGaugeFactory
   await expect(
     executorContract.connect(executorCreator).execute(
       anyCallTranslatorProxy.address,
-      ethers.utils.defaultAbiCoder.encode(
-        ["address", "bytes"],
-        [rgf.address, callData],
-      ),
+      callData,
       anyCallTranslatorProxy.address, // Pretend the call came from same address from source chain
       CHAIN_ID.ARBITRUM_MAINNET, // Source chain ID
       0, // Source nonce

--- a/deploy/mainnet/672_deploy_x_chain_gauges.ts
+++ b/deploy/mainnet/672_deploy_x_chain_gauges.ts
@@ -1,9 +1,10 @@
 import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs"
 import { expect } from "chai"
+import { BigNumber } from "ethers"
 import { DeployFunction } from "hardhat-deploy/types"
 import { HardhatRuntimeEnvironment } from "hardhat/types"
 import path from "path"
-import { AnyCallExecutor } from "../../build/typechain"
+import { AnyCallExecutor, RootGaugeFactory } from "../../build/typechain"
 import {
   BIG_NUMBER_1E18,
   convertGaugeNameToSalt,
@@ -58,38 +59,34 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   // Deploy a gauge for Arbitrum FraxBP
   const deployGaugeData = {
-    chainId: CHAIN_ID.ARBITRUM_MAINNET,
+    chainId: BigNumber.from(CHAIN_ID.ARBITRUM_MAINNET),
     salt: convertGaugeNameToSalt("Arb FraxBP"),
     gaugeName: "Arb FraxBP",
   }
 
-  let callData = await ethers
-    .getContractFactory("RootGaugeFactory")
-    .then(async (c) =>
-      c.interface.encodeFunctionData(
-        "deploy_gauge",
-        Object.values(deployGaugeData),
-      ),
-    )
-
-  // Format additional calldata for calling AnyCallTranslatorProxy.anyExecute()
-  callData = ethers.utils.defaultAbiCoder.encode(
-    ["address", "bytes"],
-    [(await get("RootGaugeFactory")).address, callData],
-  )
+  // Get RootGaugeFactory contract and interface
+  const rgf: RootGaugeFactory = await ethers.getContract("RootGaugeFactory")
+  const callData = rgf.interface.encodeFunctionData("deploy_gauge", [
+    deployGaugeData.chainId,
+    deployGaugeData.salt,
+    deployGaugeData.gaugeName,
+  ])
 
   // Call anyExecute from impersonated executor account (owned by AnyCall)
   // Then confirm new gauge was deployed via event emitted by RootGaugeFactory
   await expect(
     executorContract.connect(executorCreator).execute(
       anyCallTranslatorProxy.address,
-      callData,
+      ethers.utils.defaultAbiCoder.encode(
+        ["address", "bytes"],
+        [rgf.address, callData],
+      ),
       anyCallTranslatorProxy.address, // Pretend the call came from same address from source chain
       CHAIN_ID.ARBITRUM_MAINNET, // Source chain ID
       0, // Source nonce
     ),
   )
-    .to.emit(await ethers.getContract("RootGaugeFactory"), "DeployedGauge")
+    .to.emit(rgf, "DeployedGauge")
     .withArgs(
       anyValue,
       deployGaugeData.chainId,


### PR DESCRIPTION
Fixes mainnet fork not running due to an erorr in `672_deploy_x_chain_gauges`