### PR TITLE
Ensure xchain gauge deployments happen regardless of cache

### DIFF
--- a/deploy/mainnet/671_deploy_bridgers.ts
+++ b/deploy/mainnet/671_deploy_bridgers.ts
@@ -7,7 +7,7 @@ import { CHAIN_ID } from "../../utils/network"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts, ethers } = hre
-  const { get, execute, deploy, log } = deployments
+  const { get, execute, deploy, log, read } = deployments
   const { deployer, libraryDeployer } = await getNamedAccounts()
 
   if (process.env.HARDHAT_DEPLOY_FORK == null) {
@@ -48,7 +48,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     args: [200_000, sdlAddress, sdlAddressOnOpt],
   })
 
-  // Set Bridger
+  // Set Bridgers
   await execute(
     "RootGaugeFactory",
     executeOptions,

--- a/test/xchainGauges/anyCallTranslator.ts
+++ b/test/xchainGauges/anyCallTranslator.ts
@@ -21,6 +21,7 @@ import {
   MAX_UINT256,
   setEtherBalance,
   setTimestamp,
+  ZERO_ADDRESS,
 } from "../testUtils"
 import {
   setupAnyCallTranslator,
@@ -33,8 +34,6 @@ import {
 
 import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs"
 import * as helpers from "@nomicfoundation/hardhat-network-helpers"
-
-const { execute } = deployments
 
 const { expect } = chai
 
@@ -50,7 +49,6 @@ describe("AnyCallTranslator", () => {
   let childOracle: ChildOracle
   let dummyToken: GenericERC20
 
-  const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
   const GAUGE_NAME = "Dummy Token X-chain Gauge"
   const GAUGE_SALT = convertGaugeNameToSalt(GAUGE_NAME)
 


### PR DESCRIPTION
The root cause of the below error seems to be due to hardhat thinking `RootGauge` contract is deployed while it is not. I've used hardhat-tracer plugin to understand this issue better by running the `npx hardhat node` command without the problematic transactions and running a test command against localhost node. The test contained no setups, just the problematic call.

The trace suggested that within RootGaugeFactory.deploy_gauge(), after cloning RootGauge, calling RootGauge.initialize()  failed. Attempting to read any of original logic RootGauge's variables failed as well.

So by ensuring the deploys happen regardless of what hardhat cache understands, we can ensure each contract exists.

```
Error HH604: Error running JSON-RPC server: ERROR processing /Users/duynguyen/Saddle/saddle-contract/deploy/mainnet/672_deploy_x_chain_gauges.ts:
Error: VM Exception while processing transaction: reverted with reason string 'Target call failed'
    at AnyCallTranslator.onlyOwner (@openzeppelin/contracts-upgradeable-4.4.0/access/OwnableUpgradeable.sol:49)
    at AnyCallTranslator.anyExecute (contracts/xchainGauges/AnyCallTranslator.sol:144)
    at TransparentUpgradeableProxy._delegate (@openzeppelin/contracts-4.4.0/proxy/Proxy.sol:31)
    at TransparentUpgradeableProxy._fallback (@openzeppelin/contracts-4.4.0/proxy/Proxy.sol:60)
    at TransparentUpgradeableProxy.<fallback> (@openzeppelin/contracts-4.4.0/proxy/Proxy.sol:68)
    at <UnrecognizedContract>.<unknown> (0x0c9f0ea6317038c9d7180cf4a0aeeb58478d13a4)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:94:5)
    at async HardhatNode._mineBlockWithPendingTxs (/Users/duynguyen/Saddle/saddle-contract/node_modules/hardhat/src/internal/hardhat-network/provider/node.ts:1802:23)
    at async HardhatNode.mineBlock (/Users/duynguyen/Saddle/saddle-contract/node_modules/hardhat/src/internal/hardhat-network/provider/node.ts:491:16)
    at async EthModule._sendTransactionAndReturnHash (/Users/duynguyen/Saddle/saddle-contract/node_modules/hardhat/src/internal/hardhat-network/provider/modules/eth.ts:1522:18)
    at async HardhatNetworkProvider.request (/Users/duynguyen/Saddle/saddle-contract/node_modules/hardhat/src/internal/hardhat-network/provider/provider.ts:118:18)
    at async EthersProviderWrapper.send (/Users/duynguyen/Saddle/saddle-contract/node_modules/@nomiclabs/hardhat-ethers/src/internal/ethers-provider-wrapper.ts:13:20)
```