### PR TITLE
Change test weights to use 1e18 decimal

### DIFF
--- a/deploy/mainnet/675_forked_add_root_gauges_to_gauge_controller.ts
+++ b/deploy/mainnet/675_forked_add_root_gauges_to_gauge_controller.ts
@@ -42,7 +42,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // For each root gauge address, add it to the GaugeController from multisig
   // with weight of 100 for testing purposes
   for (const rootGauge of rootGaugeAddresses) {
-    const tx = await execute(
+    await execute(
       "GaugeController",
       executeOptions,
       "add_gauge(address,int128,uint256)",

--- a/deploy/mainnet/675_forked_add_root_gauges_to_gauge_controller.ts
+++ b/deploy/mainnet/675_forked_add_root_gauges_to_gauge_controller.ts
@@ -56,12 +56,18 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const currentBlockTimestamp = await getCurrentBlockTimestamp()
   const startOfNextWeek = Math.floor(currentBlockTimestamp / WEEK) * WEEK + WEEK
   const numOfGauges = await read("GaugeController", "n_gauges")
-  
-  for(let i = 0; i < numOfGauges; i++) {
+
+  for (let i = 0; i < numOfGauges; i++) {
     const gaugeAddress = await read("GaugeController", "gauges", i)
-    const relativeWeight = await read("GaugeController", "gauge_relative_weight_write(address,uint256)", gaugeAddress, startOfNextWeek)
-    console.log(`Gauge ${gaugeAddress} has relative weight of ${relativeWeight}`)
+    const relativeWeight = await read(
+      "GaugeController",
+      "gauge_relative_weight_write(address,uint256)",
+      gaugeAddress,
+      startOfNextWeek,
+    )
+    console.log(
+      `Gauge ${gaugeAddress} has relative weight of ${relativeWeight}`,
+    )
   }
-  
 }
 export default func


### PR DESCRIPTION
Since the enabling of on chain gauge voting, the decimals for raw weights changed.

Now each weights is incremented by voter's veSDL balance, we should use 1e18 decimals for setting weights on forks.