### PR TITLE
Fix off by 1 error in arbitrum minichef PID 3

### DIFF
--- a/forge-script/TestWithConstants.sol
+++ b/forge-script/TestWithConstants.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.2 <0.9.0;
+pragma experimental ABIEncoderV2;
+
+import "forge-std/Test.sol";
+import "forge-std/StdJson.sol";
+
+struct Network {
+    uint256 chainId;
+    string networkName;
+}
+
+contract TestWithConstants is Test {
+    using stdJson for string;
+
+    // helper variables
+    string[] public networkNames;
+    mapping(string => uint256) public networkNameToChainId;
+    mapping(uint256 => string) public chainIdToNetworkName;
+
+    function setUp() public virtual {
+        string memory root = vm.projectRoot();
+        string memory path = string(
+            abi.encodePacked(root, "/forge-script/networks.json")
+        );
+        string memory json = vm.readFile(path);
+        Network[] memory networks = abi.decode(vm.parseJson(json), (Network[]));
+
+        for (uint256 i = 0; i < networks.length; i++) {
+            Network memory network = networks[i];
+            networkNameToChainId[network.networkName] = network.chainId;
+            chainIdToNetworkName[network.chainId] = network.networkName;
+            networkNames.push(network.networkName);
+        }
+    }
+
+    function getNetworkChainId(string memory networkName)
+        public
+        view
+        returns (uint256)
+    {
+        uint256 chainId = networkNameToChainId[networkName];
+        require(chainId != 0, "invalid network name");
+        return chainId;
+    }
+
+    function getChainId() public view returns (uint256) {
+        uint256 chainId;
+        assembly {
+            chainId := chainid()
+        }
+        return chainId;
+    }
+
+    function getNetworkName() public view returns (string memory) {
+        return getNetworkName(getChainId());
+    }
+
+    function getNetworkName(uint256 chainId)
+        public
+        view
+        returns (string memory)
+    {
+        string memory networkName = chainIdToNetworkName[chainId];
+        require(bytes(networkName).length != 0, "invalid chain id");
+        return networkName;
+    }
+
+    function getDeploymentAddress(string memory deploymentJsonName)
+        public
+        returns (address)
+    {
+        return getDeploymentAddress(deploymentJsonName, getChainId());
+    }
+
+    function getDeploymentAddress(
+        string memory deploymentJsonName,
+        uint256 chainId
+    ) public returns (address) {
+        console.log(
+            "Reading deployment address for %s on chainId %s",
+            deploymentJsonName,
+            chainId
+        );
+        string memory root = vm.projectRoot();
+        string memory networkName = getNetworkName(chainId);
+        string memory path = string(
+            abi.encodePacked(
+                root,
+                "/deployments/",
+                networkName,
+                "/",
+                deploymentJsonName,
+                ".json"
+            )
+        );
+        string memory json = vm.readFile(path);
+        address addr = json.readAddress(".address");
+        require(addr != address(0), "invalid address");
+        return addr;
+    }
+}

--- a/test/foundry/ArbitrumMinichefDebtFixTest.sol
+++ b/test/foundry/ArbitrumMinichefDebtFixTest.sol
@@ -67,7 +67,7 @@ contract ArbitrumMinichefDebtFixTest is TestWithConstants {
 
     function setUp() public override {
         super.setUp();
-        // Fork arbitrum at block 61248913
+        // Fork arbitrum at block 61248913, (Feb-15-2023 08:26:16 PM +UTC)
         vm.createSelectFork("arbitrum_mainnet", 61248913);
         minichef = IMiniChefV2(getDeploymentAddress("MiniChefV2"));
         minichefOwner = minichef.owner();
@@ -104,11 +104,12 @@ contract ArbitrumMinichefDebtFixTest is TestWithConstants {
     function test_ReadingPendingSaddle() public {
         vm.startPrank(USER_ACCOUNT);
 
-        PoolInfo memory info = printPoolInfo(PID);
-        UserInfo memory userInfo = printUserInfo(PID, USER_ACCOUNT);
+        printPoolInfo(PID);
+        printUserInfo(PID, USER_ACCOUNT);
 
+        // Expect pendingSaddle to revert as is
         vm.expectRevert();
-        uint256 pending = minichef.pendingSaddle(PID, USER_ACCOUNT);
+        minichef.pendingSaddle(PID, USER_ACCOUNT);
     }
 
     // Test that pendingSaddle works after the pool is updated with a new allocPoint
@@ -116,17 +117,19 @@ contract ArbitrumMinichefDebtFixTest is TestWithConstants {
     function test_IncreasingSaddlePerSecondUnblocksPendingSaddle() public {
         vm.startPrank(minichefOwner);
 
-        PoolInfo memory info = printPoolInfo(PID);
+        printPoolInfo(PID);
         printUserInfo(PID, USER_ACCOUNT);
 
+        // Increase SaddlePerSecond and allocPoint
         minichef.setSaddlePerSecond(NEW_SADDLE_PER_SECOND);
         minichef.set(PID, NEW_ALLOC_POINT, address(0), false);
 
+        // Skip time by some duration
         vm.warp(block.timestamp + DURATION);
 
+        // Call updatePool which would modify poolInfo.accSaddleperShare
         minichef.updatePool(PID);
-
-        info = printPoolInfo(PID);
+        printPoolInfo(PID);
         printUserInfo(PID, USER_ACCOUNT);
 
         // Verify unblocks pendingSaddle
@@ -141,9 +144,11 @@ contract ArbitrumMinichefDebtFixTest is TestWithConstants {
         PoolInfo memory infoBefore = printPoolInfo(PID);
         printUserInfo(PID, USER_ACCOUNT);
 
+        // Increase SaddlePerSecond and allocPoint
         minichef.setSaddlePerSecond(NEW_SADDLE_PER_SECOND);
         minichef.set(PID, NEW_ALLOC_POINT, address(0), false);
 
+        // Skip time by some duration
         vm.warp(block.timestamp + DURATION);
 
         // Update pool after some duration to increase poolInfo.accSaddleperShare by 1
@@ -175,9 +180,11 @@ contract ArbitrumMinichefDebtFixTest is TestWithConstants {
         PoolInfo memory infoBefore = printPoolInfo(PID);
         printUserInfo(PID, USER_ACCOUNT);
 
+        // Increase SaddlePerSecond and allocPoint
         minichef.setSaddlePerSecond(NEW_SADDLE_PER_SECOND);
         minichef.set(PID, NEW_ALLOC_POINT, address(0), false);
 
+        // Skip time by some duration
         vm.warp(block.timestamp + DURATION);
 
         // Update pool after some duration to increase poolInfo.accSaddleperShare by 1

--- a/test/foundry/ArbitrumMinichefDebtFixTest.sol
+++ b/test/foundry/ArbitrumMinichefDebtFixTest.sol
@@ -161,7 +161,7 @@ contract ArbitrumMinichefDebtFixTest is TestWithConstants {
         // Assert that poolInfo.accSaddleperShare has increased by 1
         assertEq(infoBefore.accSaddlePerShare + 1, infoAfter.accSaddlePerShare);
 
-        // Verify this unblocks pendingSaddle
+        // Verify this unblocks harvest
         vm.stopPrank();
         vm.startPrank(USER_ACCOUNT);
         minichef.harvest(PID, USER_ACCOUNT);
@@ -202,7 +202,7 @@ contract ArbitrumMinichefDebtFixTest is TestWithConstants {
         // Assert that poolInfo.accSaddleperShare has increased by 1
         assertEq(infoBefore.accSaddlePerShare + 1, infoAfter.accSaddlePerShare);
 
-        // Verify this unblocks pendingSaddle
+        // Verify this unblocks harvest
         vm.stopPrank();
         vm.startPrank(USER_ACCOUNT);
         minichef.harvest(PID, USER_ACCOUNT);

--- a/test/foundry/ArbitrumMinichefDebtFixTest.sol
+++ b/test/foundry/ArbitrumMinichefDebtFixTest.sol
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import "../../forge-script/TestWithConstants.sol";
+import "forge-std/console.sol";
+
+struct PoolInfo {
+    uint128 accSaddlePerShare;
+    uint64 lastRewardTime;
+    uint64 allocPoint;
+}
+
+struct UserInfo {
+    uint256 amount;
+    int256 rewardDebt;
+}
+
+interface IMiniChefV2 {
+    function pendingSaddle(uint256 _pid, address _user)
+        external
+        view
+        returns (uint256 pending);
+
+    function setSaddlePerSecond(uint256 _saddlePerSecond) external;
+
+    function updatePool(uint256 pid) external returns (PoolInfo memory pool);
+
+    function set(
+        uint256 _pid,
+        uint256 _allocPoint,
+        address _rewarder,
+        bool overwrite
+    ) external;
+
+    function deposit(
+        uint256 pid,
+        uint256 amount,
+        address to
+    ) external;
+
+    function withdraw(
+        uint256 pid,
+        uint256 amount,
+        address to
+    ) external;
+
+    function harvest(uint256 pid, address to) external;
+
+    function owner() external view returns (address);
+
+    function poolInfo(uint256) external view returns (PoolInfo memory);
+
+    function userInfo(uint256, address) external view returns (UserInfo memory);
+}
+
+contract ArbitrumMinichefDebtFixTest is TestWithConstants {
+    IMiniChefV2 public minichef;
+    uint256 public constant PID = 3;
+    address public constant USER_ACCOUNT =
+        0x886f2d09909CaA489c745927E200AFd5aF198444;
+    address public minichefOwner;
+
+    // Params to use for the fix
+    uint256 public constant NEW_SADDLE_PER_SECOND = 2_500_000;
+    uint256 public constant DURATION = 1 days;
+    uint256 public constant NEW_ALLOC_POINT = 1000;
+
+    function setUp() public override {
+        super.setUp();
+        // Fork arbitrum at block 61248913
+        vm.createSelectFork("arbitrum_mainnet", 61248913);
+        minichef = IMiniChefV2(getDeploymentAddress("MiniChefV2"));
+        minichefOwner = minichef.owner();
+    }
+
+    // Get UserInfo and print it to the console
+    function printUserInfo(uint256 _pid, address userAddress)
+        public
+        view
+        returns (UserInfo memory)
+    {
+        UserInfo memory userInfo = minichef.userInfo(_pid, userAddress);
+        console.log(
+            "UserInfo: \n amount: %s, rewardDebt: %s",
+            userInfo.amount,
+            uint256(userInfo.rewardDebt)
+        );
+        return userInfo;
+    }
+
+    // Get PoolInfo and print it to the console
+    function printPoolInfo(uint256 _pid) public view returns (PoolInfo memory) {
+        PoolInfo memory info = minichef.poolInfo(_pid);
+        console.log(
+            "PoolInfo: \n accSaddlePerShare: %s, lastRewardTime: %s, allocPoint: %s",
+            info.accSaddlePerShare,
+            info.lastRewardTime,
+            info.allocPoint
+        );
+        return info;
+    }
+
+    // Test that pendingSaddle reverts when the pool is not updated
+    function test_ReadingPendingSaddle() public {
+        vm.startPrank(USER_ACCOUNT);
+
+        PoolInfo memory info = printPoolInfo(PID);
+        UserInfo memory userInfo = printUserInfo(PID, USER_ACCOUNT);
+
+        vm.expectRevert();
+        uint256 pending = minichef.pendingSaddle(PID, USER_ACCOUNT);
+    }
+
+    // Test that pendingSaddle works after the pool is updated with a new allocPoint
+    // and new SaddlePerSecond. Verify that the pendingSaddle call is unblocked.
+    function test_IncreasingSaddlePerSecondUnblocksPendingSaddle() public {
+        vm.startPrank(minichefOwner);
+
+        PoolInfo memory info = printPoolInfo(PID);
+        printUserInfo(PID, USER_ACCOUNT);
+
+        minichef.setSaddlePerSecond(NEW_SADDLE_PER_SECOND);
+        minichef.set(PID, NEW_ALLOC_POINT, address(0), false);
+
+        vm.warp(block.timestamp + DURATION);
+
+        minichef.updatePool(PID);
+
+        info = printPoolInfo(PID);
+        printUserInfo(PID, USER_ACCOUNT);
+
+        // Verify unblocks pendingSaddle
+        uint256 pending = minichef.pendingSaddle(PID, USER_ACCOUNT);
+        console.log("pendingSaddle() after %s seconds : %s", DURATION, pending);
+    }
+
+    // Test that harvest is unblocked after the pool is updated.
+    function test_IncreasingSaddlePerSecondUnblocksHarvest() public {
+        vm.startPrank(minichefOwner);
+
+        PoolInfo memory infoBefore = printPoolInfo(PID);
+        printUserInfo(PID, USER_ACCOUNT);
+
+        minichef.setSaddlePerSecond(NEW_SADDLE_PER_SECOND);
+        minichef.set(PID, NEW_ALLOC_POINT, address(0), false);
+
+        vm.warp(block.timestamp + DURATION);
+
+        // Update pool after some duration to increase poolInfo.accSaddleperShare by 1
+        minichef.updatePool(PID);
+
+        // Verify the change in poolInfo.accSaddleperShare
+        PoolInfo memory infoAfter = printPoolInfo(PID);
+        printUserInfo(PID, USER_ACCOUNT);
+
+        // Assert that poolInfo.accSaddleperShare has increased by 1
+        assertEq(infoBefore.accSaddlePerShare + 1, infoAfter.accSaddlePerShare);
+
+        // Verify this unblocks pendingSaddle
+        vm.stopPrank();
+        vm.startPrank(USER_ACCOUNT);
+        minichef.harvest(PID, USER_ACCOUNT);
+
+        // Verify pendingSaddle works after harvest
+        printUserInfo(PID, USER_ACCOUNT);
+        uint256 pending = minichef.pendingSaddle(PID, USER_ACCOUNT);
+        assertEq(pending, 0);
+    }
+
+    // Test that fix works even after setting allocPoint and SaddlePerSecond to 0
+    // if the duration with the new allocPoint and SaddlePerSecond is long enough.
+    function test_IncreasingSaddlePerSecondThenSettingToZeroFix() public {
+        vm.startPrank(minichefOwner);
+
+        PoolInfo memory infoBefore = printPoolInfo(PID);
+        printUserInfo(PID, USER_ACCOUNT);
+
+        minichef.setSaddlePerSecond(NEW_SADDLE_PER_SECOND);
+        minichef.set(PID, NEW_ALLOC_POINT, address(0), false);
+
+        vm.warp(block.timestamp + DURATION);
+
+        // Update pool after some duration to increase poolInfo.accSaddleperShare by 1
+        minichef.updatePool(PID);
+
+        // Set SaddlePerSecond and allocPoint to 0 again to prevent future rewards
+        minichef.setSaddlePerSecond(0);
+        minichef.set(PID, 0, address(0), false);
+        minichef.updatePool(PID);
+
+        // Verify the change in poolInfo.accSaddleperShare
+        PoolInfo memory infoAfter = printPoolInfo(PID);
+        printUserInfo(PID, USER_ACCOUNT);
+
+        // Assert that poolInfo.accSaddleperShare has increased by 1
+        assertEq(infoBefore.accSaddlePerShare + 1, infoAfter.accSaddlePerShare);
+
+        // Verify this unblocks pendingSaddle
+        vm.stopPrank();
+        vm.startPrank(USER_ACCOUNT);
+        minichef.harvest(PID, USER_ACCOUNT);
+
+        // Verify pendingSaddle works after harvest
+        printUserInfo(PID, USER_ACCOUNT);
+        uint256 pending = minichef.pendingSaddle(PID, USER_ACCOUNT);
+        assertEq(pending, 0);
+    }
+}


### PR DESCRIPTION
* Add `TestWithConstants.sol`, extension of Test.sol with ability to read deployment related files
* Add `ArbitrumMinichefDebtFixTest.sol` to test if the fix is valid for offsetting debt off by 1 error.
  -  Increase saddlePerSecond and allocPoint for 24 hours. Then call updatePool(). After, reset params to 0 to prevent future rewards.

```

Running 4 tests for test/foundry/ArbitrumMinichefDebtFixTest.sol:ArbitrumMinichefDebtFixTest
[PASS] test_IncreasingSaddlePerSecondThenSettingToZeroFix() (gas: 136355)
Logs:
  Reading deployment address for MiniChefV2 on chainId 42161
  PoolInfo: 
 accSaddlePerShare: 2031836497669981, lastRewardTime: 1676043638, allocPoint: 0
  UserInfo: 
 amount: 1206015373508071357616988, rewardDebt: 2450426052644793694444846322
  PoolInfo: 
 accSaddlePerShare: 2031836497669982, lastRewardTime: 1676579176, allocPoint: 0
  UserInfo: 
 amount: 1206015373508071357616988, rewardDebt: 2450426052644793694444846322
  UserInfo: 
 amount: 1206015373508071357616988, rewardDebt: 2450426052644794900460219829

[PASS] test_IncreasingSaddlePerSecondUnblocksHarvest() (gas: 150207)
Logs:
  Reading deployment address for MiniChefV2 on chainId 42161
  PoolInfo: 
 accSaddlePerShare: 2031836497669981, lastRewardTime: 1676043638, allocPoint: 0
  UserInfo: 
 amount: 1206015373508071357616988, rewardDebt: 2450426052644793694444846322
  PoolInfo: 
 accSaddlePerShare: 2031836497669982, lastRewardTime: 1676579176, allocPoint: 1000
  UserInfo: 
 amount: 1206015373508071357616988, rewardDebt: 2450426052644793694444846322
  UserInfo: 
 amount: 1206015373508071357616988, rewardDebt: 2450426052644794900460219829

[PASS] test_IncreasingSaddlePerSecondUnblocksPendingSaddle() (gas: 96155)
Logs:
  Reading deployment address for MiniChefV2 on chainId 42161
  PoolInfo: 
 accSaddlePerShare: 2031836497669981, lastRewardTime: 1676043638, allocPoint: 0
  UserInfo: 
 amount: 1206015373508071357616988, rewardDebt: 2450426052644793694444846322
  PoolInfo: 
 accSaddlePerShare: 2031836497669982, lastRewardTime: 1676579176, allocPoint: 1000
  UserInfo: 
 amount: 1206015373508071357616988, rewardDebt: 2450426052644793694444846322
  pendingSaddle() after 86400 seconds : 1206015373507

[PASS] test_ReadingPendingSaddle() (gas: 43318)
Logs:
  Reading deployment address for MiniChefV2 on chainId 42161
  PoolInfo: 
 accSaddlePerShare: 2031836497669981, lastRewardTime: 1676043638, allocPoint: 0
  UserInfo: 
 amount: 1206015373508071357616988, rewardDebt: 2450426052644793694444846322

Test result: ok. 4 passed; 0 failed; finished in 145.48ms
```