### PR TITLE
Update Utils, ChildGauge Manager Update

### DIFF
--- a/deploy/arbitrum/270_update_childGauges_manager.ts
+++ b/deploy/arbitrum/270_update_childGauges_manager.ts
@@ -1,0 +1,35 @@
+import { ethers } from "hardhat"
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { ChildGauge } from "../../build/typechain"
+import { OPS_MULTISIG_ADDRESSES } from "../../utils/accounts"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { execute } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const allDeploys = await deployments.all()
+  for (const contractName in allDeploys) {
+    if (
+      contractName.startsWith("ChildGauge") &&
+      contractName.includes("LPToken")
+    ) {
+      const childGaugeContract: ChildGauge = (await ethers.getContract(
+        contractName,
+      )) as ChildGauge
+      if (
+        (await childGaugeContract.manager()) !=
+        OPS_MULTISIG_ADDRESSES[await getChainId()]
+      ) {
+        await execute(
+          contractName,
+          { from: deployer, log: true },
+          "set_manager",
+          OPS_MULTISIG_ADDRESSES[await getChainId()],
+        )
+      }
+    }
+  }
+}
+export default func

--- a/deploy/arbitrum/271_deploy_updated_utils.ts
+++ b/deploy/arbitrum/271_deploy_updated_utils.ts
@@ -1,0 +1,120 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { deploy, execute, getOrNull, log, get } = deployments
+  const { libraryDeployer, deployer } = await getNamedAccounts()
+
+  let lpTokenV2 = await getOrNull("LPTokenV2")
+  if (lpTokenV2) {
+    log(`reusing "LPToken" at ${lpTokenV2.address}`)
+  } else {
+    lpTokenV2 = await deploy("LPTokenV2", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+
+    await execute(
+      "LPTokenV2",
+      { from: libraryDeployer, log: true },
+      "initialize",
+      "Saddle LP Token (Target)",
+      "saddleLPTokenTarget",
+    )
+  }
+
+  let amplificationUtilsV2 = await getOrNull("AmplificationUtilsV2")
+  if (amplificationUtilsV2) {
+    log(`reusing "AmplificationUtilsV2" at ${amplificationUtilsV2.address}`)
+  } else {
+    amplificationUtilsV2 = await deploy("AmplificationUtilsV2", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let swapUtilsV2 = await getOrNull("SwapUtilsV2")
+  if (swapUtilsV2) {
+    log(`reusing "SwapUtilsV2" at ${swapUtilsV2.address}`)
+  } else {
+    swapUtilsV2 = await deploy("SwapUtilsV2", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let metaSwapUtilsV1 = await getOrNull("MetaSwapUtilsV1")
+  if (metaSwapUtilsV1) {
+    log(`reusing "MetaSwapUtilsV1" at ${metaSwapUtilsV1.address}`)
+  } else {
+    metaSwapUtilsV1 = await deploy("MetaSwapUtilsV1", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let metaswapDepositV1 = await getOrNull("MetaSwapDepoistV1")
+  if (metaswapDepositV1) {
+    log(`reusing "MetaSwapUtilsV2" at ${metaswapDepositV1.address}`)
+  } else {
+    metaswapDepositV1 = await deploy("MetaSwapDepositV1", {
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let permissionlessSwapV1 = await getOrNull("PermissionlessSwapV1")
+  if (permissionlessSwapV1) {
+    log(`reusing "PermissionlessSwapV1" at ${permissionlessSwapV1.address}`)
+  } else {
+    permissionlessSwapV1 = await deploy("PermissionlessSwapV1", {
+      contract: "PermissionlessSwap",
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+      args: [(await get("MasterRegistry")).address],
+      libraries: {
+        SwapUtils: swapUtilsV2.address,
+        AmplificationUtils: amplificationUtilsV2.address,
+      },
+    })
+  }
+
+  let permissionlessMetaSwapV1 = await getOrNull("PermissionlessMetaSwapV1")
+  if (permissionlessMetaSwapV1) {
+    log(
+      `reusing "PermissionlessMetaSwapV1" at ${permissionlessMetaSwapV1.address}`,
+    )
+  } else {
+    permissionlessMetaSwapV1 = await deploy("PermissionlessMetaSwapV1", {
+      contract: "PermissionlessMetaSwap",
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+      args: [(await get("MasterRegistry")).address],
+      libraries: {
+        SwapUtils: swapUtilsV2.address,
+        MetaSwapUtils: metaSwapUtilsV1.address,
+        AmplificationUtils: amplificationUtilsV2.address,
+      },
+    })
+  }
+}
+export default func
+func.tags = [
+  "LPTokenV2",
+  "AmplificationUtilsV2",
+  "SwapUtilsV2",
+  "SwapV2",
+  "SwapFlashLoanV1",
+  "PermissionlessMetaSwapV1",
+  "PermissionlessSwapV1",
+  "MetaSwapUtilsV1",
+  "MetaSwapDepositV1",
+]

--- a/deploy/arbitrum/272_update_permissionless_deployment_targets.ts
+++ b/deploy/arbitrum/272_update_permissionless_deployment_targets.ts
@@ -1,0 +1,96 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { ethers } from "hardhat"
+import { PermissionlessDeployer } from "../../build/typechain"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, log, get } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const permissionlessSwapV1 = await get("PermissionlessSwapV1")
+  const permissionlessMetaSwapV1 = await get("PermissionlessMetaSwapV1")
+  const lpTokenV2 = await get("LPTokenV2")
+  const metaswapDepositV1 = await get("MetaSwapDepositV1")
+
+  const permissionlessDeployer: PermissionlessDeployer =
+    (await ethers.getContract(
+      "PermissionlessDeployer",
+    )) as PermissionlessDeployer
+  if (
+    await permissionlessDeployer.hasRole(
+      await permissionlessDeployer.SADDLE_MANAGER_ROLE(),
+      deployer,
+    )
+  ) {
+    // If LPTokenV2 is not already set as the target LPToken, set it
+    const targetLPToken = await permissionlessDeployer.targetLPToken()
+    if (targetLPToken != lpTokenV2.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetLPToken",
+        lpTokenV2.address,
+      )
+    }
+    // If PermissionlessSwapV1 is not already set as the target Swap, set it
+    const targetSwap = await permissionlessDeployer.targetSwap()
+    if (targetSwap != permissionlessSwapV1.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetSwap",
+        permissionlessSwapV1.address,
+      )
+    }
+    // If PermissionlessMetaSwapV1 is not already set as the target MetaSwap, set it
+    const targetMetaSwap = await permissionlessDeployer.targetMetaSwap()
+    if (targetMetaSwap != permissionlessMetaSwapV1.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetMetaSwap",
+        permissionlessMetaSwapV1.address,
+      )
+    }
+    // If MetaSwapDepoistV1 is not already set as the target MetaSwapDeposit, set it
+    const targetMetaSwapDeposit =
+      await permissionlessDeployer.targetMetaSwapDeposit()
+    if (targetMetaSwapDeposit != metaswapDepositV1.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetMetaSwapDeposit",
+        metaswapDepositV1.address,
+      )
+    }
+  } else {
+    const targetSwap = await permissionlessDeployer.targetSwap()
+    const targetMetaSwap = await permissionlessDeployer.targetMetaSwap()
+    if (
+      targetSwap != permissionlessSwapV1.address ||
+      targetMetaSwap != permissionlessMetaSwapV1.address
+    ) {
+      log(
+        `PermissionlessDeployer targets are out of date, must be updated by multisig`,
+      )
+      const manager = await permissionlessDeployer.getRoleMember(
+        await permissionlessDeployer.SADDLE_MANAGER_ROLE(),
+        0,
+      )
+      log(`Currnet manager is ${manager}`)
+    }
+  }
+}
+export default func
+func.dependencies = [
+  "LPTokenV2",
+  "AmplificationUtilsV2",
+  "SwapUtilsV2",
+  "SwapV2",
+  "SwapFlashLoanV1",
+  "PermissionlessMetaSwapV1",
+  "PermissionlessSwapV1",
+  "MetaSwapUtilsV1",
+  "MetaSwapDepoistV1",
+]

--- a/deploy/aurora_mainnet/120_deploy_updated_utils.ts
+++ b/deploy/aurora_mainnet/120_deploy_updated_utils.ts
@@ -1,0 +1,120 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { deploy, execute, getOrNull, log, get } = deployments
+  const { libraryDeployer, deployer } = await getNamedAccounts()
+
+  let lpTokenV2 = await getOrNull("LPTokenV2")
+  if (lpTokenV2) {
+    log(`reusing "LPToken" at ${lpTokenV2.address}`)
+  } else {
+    lpTokenV2 = await deploy("LPTokenV2", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+
+    await execute(
+      "LPTokenV2",
+      { from: libraryDeployer, log: true },
+      "initialize",
+      "Saddle LP Token (Target)",
+      "saddleLPTokenTarget",
+    )
+  }
+
+  let amplificationUtilsV2 = await getOrNull("AmplificationUtilsV2")
+  if (amplificationUtilsV2) {
+    log(`reusing "AmplificationUtilsV2" at ${amplificationUtilsV2.address}`)
+  } else {
+    amplificationUtilsV2 = await deploy("AmplificationUtilsV2", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let swapUtilsV2 = await getOrNull("SwapUtilsV2")
+  if (swapUtilsV2) {
+    log(`reusing "SwapUtilsV2" at ${swapUtilsV2.address}`)
+  } else {
+    swapUtilsV2 = await deploy("SwapUtilsV2", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let metaSwapUtilsV1 = await getOrNull("MetaSwapUtilsV1")
+  if (metaSwapUtilsV1) {
+    log(`reusing "MetaSwapUtilsV1" at ${metaSwapUtilsV1.address}`)
+  } else {
+    metaSwapUtilsV1 = await deploy("MetaSwapUtilsV1", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let metaswapDepositV1 = await getOrNull("MetaSwapDepoistV1")
+  if (metaswapDepositV1) {
+    log(`reusing "MetaSwapUtilsV2" at ${metaswapDepositV1.address}`)
+  } else {
+    metaswapDepositV1 = await deploy("MetaSwapDepositV1", {
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let permissionlessSwapV1 = await getOrNull("PermissionlessSwapV1")
+  if (permissionlessSwapV1) {
+    log(`reusing "PermissionlessSwapV1" at ${permissionlessSwapV1.address}`)
+  } else {
+    permissionlessSwapV1 = await deploy("PermissionlessSwapV1", {
+      contract: "PermissionlessSwap",
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+      args: [(await get("MasterRegistry")).address],
+      libraries: {
+        SwapUtils: swapUtilsV2.address,
+        AmplificationUtils: amplificationUtilsV2.address,
+      },
+    })
+  }
+
+  let permissionlessMetaSwapV1 = await getOrNull("PermissionlessMetaSwapV1")
+  if (permissionlessMetaSwapV1) {
+    log(
+      `reusing "PermissionlessMetaSwapV1" at ${permissionlessMetaSwapV1.address}`,
+    )
+  } else {
+    permissionlessMetaSwapV1 = await deploy("PermissionlessMetaSwapV1", {
+      contract: "PermissionlessMetaSwap",
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+      args: [(await get("MasterRegistry")).address],
+      libraries: {
+        SwapUtils: swapUtilsV2.address,
+        MetaSwapUtils: metaSwapUtilsV1.address,
+        AmplificationUtils: amplificationUtilsV2.address,
+      },
+    })
+  }
+}
+export default func
+func.tags = [
+  "LPTokenV2",
+  "AmplificationUtilsV2",
+  "SwapUtilsV2",
+  "SwapV2",
+  "SwapFlashLoanV1",
+  "PermissionlessMetaSwapV1",
+  "PermissionlessSwapV1",
+  "MetaSwapUtilsV1",
+  "MetaSwapDepositV1",
+]

--- a/deploy/aurora_mainnet/121_update_permissionless_deployment_targets.ts
+++ b/deploy/aurora_mainnet/121_update_permissionless_deployment_targets.ts
@@ -1,0 +1,96 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { ethers } from "hardhat"
+import { PermissionlessDeployer } from "../../build/typechain"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, log, get } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const permissionlessSwapV1 = await get("PermissionlessSwapV1")
+  const permissionlessMetaSwapV1 = await get("PermissionlessMetaSwapV1")
+  const lpTokenV2 = await get("LPTokenV2")
+  const metaswapDepositV1 = await get("MetaSwapDepositV1")
+
+  const permissionlessDeployer: PermissionlessDeployer =
+    (await ethers.getContract(
+      "PermissionlessDeployer",
+    )) as PermissionlessDeployer
+  if (
+    await permissionlessDeployer.hasRole(
+      await permissionlessDeployer.SADDLE_MANAGER_ROLE(),
+      deployer,
+    )
+  ) {
+    // If LPTokenV2 is not already set as the target LPToken, set it
+    const targetLPToken = await permissionlessDeployer.targetLPToken()
+    if (targetLPToken != lpTokenV2.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetLPToken",
+        lpTokenV2.address,
+      )
+    }
+    // If PermissionlessSwapV1 is not already set as the target Swap, set it
+    const targetSwap = await permissionlessDeployer.targetSwap()
+    if (targetSwap != permissionlessSwapV1.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetSwap",
+        permissionlessSwapV1.address,
+      )
+    }
+    // If PermissionlessMetaSwapV1 is not already set as the target MetaSwap, set it
+    const targetMetaSwap = await permissionlessDeployer.targetMetaSwap()
+    if (targetMetaSwap != permissionlessMetaSwapV1.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetMetaSwap",
+        permissionlessMetaSwapV1.address,
+      )
+    }
+    // If MetaSwapDepoistV1 is not already set as the target MetaSwapDeposit, set it
+    const targetMetaSwapDeposit =
+      await permissionlessDeployer.targetMetaSwapDeposit()
+    if (targetMetaSwapDeposit != metaswapDepositV1.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetMetaSwapDeposit",
+        metaswapDepositV1.address,
+      )
+    }
+  } else {
+    const targetSwap = await permissionlessDeployer.targetSwap()
+    const targetMetaSwap = await permissionlessDeployer.targetMetaSwap()
+    if (
+      targetSwap != permissionlessSwapV1.address ||
+      targetMetaSwap != permissionlessMetaSwapV1.address
+    ) {
+      log(
+        `PermissionlessDeployer targets are out of date, must be updated by multisig`,
+      )
+      const manager = await permissionlessDeployer.getRoleMember(
+        await permissionlessDeployer.SADDLE_MANAGER_ROLE(),
+        0,
+      )
+      log(`Currnet manager is ${manager}`)
+    }
+  }
+}
+export default func
+func.dependencies = [
+  "LPTokenV2",
+  "AmplificationUtilsV2",
+  "SwapUtilsV2",
+  "SwapV2",
+  "SwapFlashLoanV1",
+  "PermissionlessMetaSwapV1",
+  "PermissionlessSwapV1",
+  "MetaSwapUtilsV1",
+  "MetaSwapDepoistV1",
+]

--- a/deploy/evmos/220_deploy_updated_utils.ts
+++ b/deploy/evmos/220_deploy_updated_utils.ts
@@ -1,0 +1,120 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { deploy, execute, getOrNull, log, get } = deployments
+  const { libraryDeployer, deployer } = await getNamedAccounts()
+
+  let lpTokenV2 = await getOrNull("LPTokenV2")
+  if (lpTokenV2) {
+    log(`reusing "LPToken" at ${lpTokenV2.address}`)
+  } else {
+    lpTokenV2 = await deploy("LPTokenV2", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+
+    await execute(
+      "LPTokenV2",
+      { from: libraryDeployer, log: true },
+      "initialize",
+      "Saddle LP Token (Target)",
+      "saddleLPTokenTarget",
+    )
+  }
+
+  let amplificationUtilsV2 = await getOrNull("AmplificationUtilsV2")
+  if (amplificationUtilsV2) {
+    log(`reusing "AmplificationUtilsV2" at ${amplificationUtilsV2.address}`)
+  } else {
+    amplificationUtilsV2 = await deploy("AmplificationUtilsV2", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let swapUtilsV2 = await getOrNull("SwapUtilsV2")
+  if (swapUtilsV2) {
+    log(`reusing "SwapUtilsV2" at ${swapUtilsV2.address}`)
+  } else {
+    swapUtilsV2 = await deploy("SwapUtilsV2", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let metaSwapUtilsV1 = await getOrNull("MetaSwapUtilsV1")
+  if (metaSwapUtilsV1) {
+    log(`reusing "MetaSwapUtilsV1" at ${metaSwapUtilsV1.address}`)
+  } else {
+    metaSwapUtilsV1 = await deploy("MetaSwapUtilsV1", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let metaswapDepositV1 = await getOrNull("MetaSwapDepoistV1")
+  if (metaswapDepositV1) {
+    log(`reusing "MetaSwapUtilsV2" at ${metaswapDepositV1.address}`)
+  } else {
+    metaswapDepositV1 = await deploy("MetaSwapDepositV1", {
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let permissionlessSwapV1 = await getOrNull("PermissionlessSwapV1")
+  if (permissionlessSwapV1) {
+    log(`reusing "PermissionlessSwapV1" at ${permissionlessSwapV1.address}`)
+  } else {
+    permissionlessSwapV1 = await deploy("PermissionlessSwapV1", {
+      contract: "PermissionlessSwap",
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+      args: [(await get("MasterRegistry")).address],
+      libraries: {
+        SwapUtils: swapUtilsV2.address,
+        AmplificationUtils: amplificationUtilsV2.address,
+      },
+    })
+  }
+
+  let permissionlessMetaSwapV1 = await getOrNull("PermissionlessMetaSwapV1")
+  if (permissionlessMetaSwapV1) {
+    log(
+      `reusing "PermissionlessMetaSwapV1" at ${permissionlessMetaSwapV1.address}`,
+    )
+  } else {
+    permissionlessMetaSwapV1 = await deploy("PermissionlessMetaSwapV1", {
+      contract: "PermissionlessMetaSwap",
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+      args: [(await get("MasterRegistry")).address],
+      libraries: {
+        SwapUtils: swapUtilsV2.address,
+        MetaSwapUtils: metaSwapUtilsV1.address,
+        AmplificationUtils: amplificationUtilsV2.address,
+      },
+    })
+  }
+}
+export default func
+func.tags = [
+  "LPTokenV2",
+  "AmplificationUtilsV2",
+  "SwapUtilsV2",
+  "SwapV2",
+  "SwapFlashLoanV1",
+  "PermissionlessMetaSwapV1",
+  "PermissionlessSwapV1",
+  "MetaSwapUtilsV1",
+  "MetaSwapDepositV1",
+]

--- a/deploy/evmos/221_update_permissionless_deployment_targets.ts
+++ b/deploy/evmos/221_update_permissionless_deployment_targets.ts
@@ -1,0 +1,96 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { ethers } from "hardhat"
+import { PermissionlessDeployer } from "../../build/typechain"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, log, get } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const permissionlessSwapV1 = await get("PermissionlessSwapV1")
+  const permissionlessMetaSwapV1 = await get("PermissionlessMetaSwapV1")
+  const lpTokenV2 = await get("LPTokenV2")
+  const metaswapDepositV1 = await get("MetaSwapDepositV1")
+
+  const permissionlessDeployer: PermissionlessDeployer =
+    (await ethers.getContract(
+      "PermissionlessDeployer",
+    )) as PermissionlessDeployer
+  if (
+    await permissionlessDeployer.hasRole(
+      await permissionlessDeployer.SADDLE_MANAGER_ROLE(),
+      deployer,
+    )
+  ) {
+    // If LPTokenV2 is not already set as the target LPToken, set it
+    const targetLPToken = await permissionlessDeployer.targetLPToken()
+    if (targetLPToken != lpTokenV2.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetLPToken",
+        lpTokenV2.address,
+      )
+    }
+    // If PermissionlessSwapV1 is not already set as the target Swap, set it
+    const targetSwap = await permissionlessDeployer.targetSwap()
+    if (targetSwap != permissionlessSwapV1.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetSwap",
+        permissionlessSwapV1.address,
+      )
+    }
+    // If PermissionlessMetaSwapV1 is not already set as the target MetaSwap, set it
+    const targetMetaSwap = await permissionlessDeployer.targetMetaSwap()
+    if (targetMetaSwap != permissionlessMetaSwapV1.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetMetaSwap",
+        permissionlessMetaSwapV1.address,
+      )
+    }
+    // If MetaSwapDepoistV1 is not already set as the target MetaSwapDeposit, set it
+    const targetMetaSwapDeposit =
+      await permissionlessDeployer.targetMetaSwapDeposit()
+    if (targetMetaSwapDeposit != metaswapDepositV1.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetMetaSwapDeposit",
+        metaswapDepositV1.address,
+      )
+    }
+  } else {
+    const targetSwap = await permissionlessDeployer.targetSwap()
+    const targetMetaSwap = await permissionlessDeployer.targetMetaSwap()
+    if (
+      targetSwap != permissionlessSwapV1.address ||
+      targetMetaSwap != permissionlessMetaSwapV1.address
+    ) {
+      log(
+        `PermissionlessDeployer targets are out of date, must be updated by multisig`,
+      )
+      const manager = await permissionlessDeployer.getRoleMember(
+        await permissionlessDeployer.SADDLE_MANAGER_ROLE(),
+        0,
+      )
+      log(`Currnet manager is ${manager}`)
+    }
+  }
+}
+export default func
+func.dependencies = [
+  "LPTokenV2",
+  "AmplificationUtilsV2",
+  "SwapUtilsV2",
+  "SwapV2",
+  "SwapFlashLoanV1",
+  "PermissionlessMetaSwapV1",
+  "PermissionlessSwapV1",
+  "MetaSwapUtilsV1",
+  "MetaSwapDepoistV1",
+]

--- a/deploy/fantom/210_deploy_updated_utils.ts
+++ b/deploy/fantom/210_deploy_updated_utils.ts
@@ -1,0 +1,120 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { deploy, execute, getOrNull, log, get } = deployments
+  const { libraryDeployer, deployer } = await getNamedAccounts()
+
+  let lpTokenV2 = await getOrNull("LPTokenV2")
+  if (lpTokenV2) {
+    log(`reusing "LPToken" at ${lpTokenV2.address}`)
+  } else {
+    lpTokenV2 = await deploy("LPTokenV2", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+
+    await execute(
+      "LPTokenV2",
+      { from: libraryDeployer, log: true },
+      "initialize",
+      "Saddle LP Token (Target)",
+      "saddleLPTokenTarget",
+    )
+  }
+
+  let amplificationUtilsV2 = await getOrNull("AmplificationUtilsV2")
+  if (amplificationUtilsV2) {
+    log(`reusing "AmplificationUtilsV2" at ${amplificationUtilsV2.address}`)
+  } else {
+    amplificationUtilsV2 = await deploy("AmplificationUtilsV2", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let swapUtilsV2 = await getOrNull("SwapUtilsV2")
+  if (swapUtilsV2) {
+    log(`reusing "SwapUtilsV2" at ${swapUtilsV2.address}`)
+  } else {
+    swapUtilsV2 = await deploy("SwapUtilsV2", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let metaSwapUtilsV1 = await getOrNull("MetaSwapUtilsV1")
+  if (metaSwapUtilsV1) {
+    log(`reusing "MetaSwapUtilsV1" at ${metaSwapUtilsV1.address}`)
+  } else {
+    metaSwapUtilsV1 = await deploy("MetaSwapUtilsV1", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let metaswapDepositV1 = await getOrNull("MetaSwapDepoistV1")
+  if (metaswapDepositV1) {
+    log(`reusing "MetaSwapUtilsV2" at ${metaswapDepositV1.address}`)
+  } else {
+    metaswapDepositV1 = await deploy("MetaSwapDepositV1", {
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let permissionlessSwapV1 = await getOrNull("PermissionlessSwapV1")
+  if (permissionlessSwapV1) {
+    log(`reusing "PermissionlessSwapV1" at ${permissionlessSwapV1.address}`)
+  } else {
+    permissionlessSwapV1 = await deploy("PermissionlessSwapV1", {
+      contract: "PermissionlessSwap",
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+      args: [(await get("MasterRegistry")).address],
+      libraries: {
+        SwapUtils: swapUtilsV2.address,
+        AmplificationUtils: amplificationUtilsV2.address,
+      },
+    })
+  }
+
+  let permissionlessMetaSwapV1 = await getOrNull("PermissionlessMetaSwapV1")
+  if (permissionlessMetaSwapV1) {
+    log(
+      `reusing "PermissionlessMetaSwapV1" at ${permissionlessMetaSwapV1.address}`,
+    )
+  } else {
+    permissionlessMetaSwapV1 = await deploy("PermissionlessMetaSwapV1", {
+      contract: "PermissionlessMetaSwap",
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+      args: [(await get("MasterRegistry")).address],
+      libraries: {
+        SwapUtils: swapUtilsV2.address,
+        MetaSwapUtils: metaSwapUtilsV1.address,
+        AmplificationUtils: amplificationUtilsV2.address,
+      },
+    })
+  }
+}
+export default func
+func.tags = [
+  "LPTokenV2",
+  "AmplificationUtilsV2",
+  "SwapUtilsV2",
+  "SwapV2",
+  "SwapFlashLoanV1",
+  "PermissionlessMetaSwapV1",
+  "PermissionlessSwapV1",
+  "MetaSwapUtilsV1",
+  "MetaSwapDepositV1",
+]

--- a/deploy/fantom/211_update_permissionless_deployment_targets.ts
+++ b/deploy/fantom/211_update_permissionless_deployment_targets.ts
@@ -1,0 +1,96 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { ethers } from "hardhat"
+import { PermissionlessDeployer } from "../../build/typechain"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, log, get } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const permissionlessSwapV1 = await get("PermissionlessSwapV1")
+  const permissionlessMetaSwapV1 = await get("PermissionlessMetaSwapV1")
+  const lpTokenV2 = await get("LPTokenV2")
+  const metaswapDepositV1 = await get("MetaSwapDepositV1")
+
+  const permissionlessDeployer: PermissionlessDeployer =
+    (await ethers.getContract(
+      "PermissionlessDeployer",
+    )) as PermissionlessDeployer
+  if (
+    await permissionlessDeployer.hasRole(
+      await permissionlessDeployer.SADDLE_MANAGER_ROLE(),
+      deployer,
+    )
+  ) {
+    // If LPTokenV2 is not already set as the target LPToken, set it
+    const targetLPToken = await permissionlessDeployer.targetLPToken()
+    if (targetLPToken != lpTokenV2.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetLPToken",
+        lpTokenV2.address,
+      )
+    }
+    // If PermissionlessSwapV1 is not already set as the target Swap, set it
+    const targetSwap = await permissionlessDeployer.targetSwap()
+    if (targetSwap != permissionlessSwapV1.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetSwap",
+        permissionlessSwapV1.address,
+      )
+    }
+    // If PermissionlessMetaSwapV1 is not already set as the target MetaSwap, set it
+    const targetMetaSwap = await permissionlessDeployer.targetMetaSwap()
+    if (targetMetaSwap != permissionlessMetaSwapV1.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetMetaSwap",
+        permissionlessMetaSwapV1.address,
+      )
+    }
+    // If MetaSwapDepoistV1 is not already set as the target MetaSwapDeposit, set it
+    const targetMetaSwapDeposit =
+      await permissionlessDeployer.targetMetaSwapDeposit()
+    if (targetMetaSwapDeposit != metaswapDepositV1.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetMetaSwapDeposit",
+        metaswapDepositV1.address,
+      )
+    }
+  } else {
+    const targetSwap = await permissionlessDeployer.targetSwap()
+    const targetMetaSwap = await permissionlessDeployer.targetMetaSwap()
+    if (
+      targetSwap != permissionlessSwapV1.address ||
+      targetMetaSwap != permissionlessMetaSwapV1.address
+    ) {
+      log(
+        `PermissionlessDeployer targets are out of date, must be updated by multisig`,
+      )
+      const manager = await permissionlessDeployer.getRoleMember(
+        await permissionlessDeployer.SADDLE_MANAGER_ROLE(),
+        0,
+      )
+      log(`Currnet manager is ${manager}`)
+    }
+  }
+}
+export default func
+func.dependencies = [
+  "LPTokenV2",
+  "AmplificationUtilsV2",
+  "SwapUtilsV2",
+  "SwapV2",
+  "SwapFlashLoanV1",
+  "PermissionlessMetaSwapV1",
+  "PermissionlessSwapV1",
+  "MetaSwapUtilsV1",
+  "MetaSwapDepoistV1",
+]

--- a/deploy/kava_mainnet/200_deploy_updated_utils.ts
+++ b/deploy/kava_mainnet/200_deploy_updated_utils.ts
@@ -1,0 +1,120 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { deploy, execute, getOrNull, log, get } = deployments
+  const { libraryDeployer, deployer } = await getNamedAccounts()
+
+  let lpTokenV2 = await getOrNull("LPTokenV2")
+  if (lpTokenV2) {
+    log(`reusing "LPToken" at ${lpTokenV2.address}`)
+  } else {
+    lpTokenV2 = await deploy("LPTokenV2", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+
+    await execute(
+      "LPTokenV2",
+      { from: libraryDeployer, log: true },
+      "initialize",
+      "Saddle LP Token (Target)",
+      "saddleLPTokenTarget",
+    )
+  }
+
+  let amplificationUtilsV2 = await getOrNull("AmplificationUtilsV2")
+  if (amplificationUtilsV2) {
+    log(`reusing "AmplificationUtilsV2" at ${amplificationUtilsV2.address}`)
+  } else {
+    amplificationUtilsV2 = await deploy("AmplificationUtilsV2", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let swapUtilsV2 = await getOrNull("SwapUtilsV2")
+  if (swapUtilsV2) {
+    log(`reusing "SwapUtilsV2" at ${swapUtilsV2.address}`)
+  } else {
+    swapUtilsV2 = await deploy("SwapUtilsV2", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let metaSwapUtilsV1 = await getOrNull("MetaSwapUtilsV1")
+  if (metaSwapUtilsV1) {
+    log(`reusing "MetaSwapUtilsV1" at ${metaSwapUtilsV1.address}`)
+  } else {
+    metaSwapUtilsV1 = await deploy("MetaSwapUtilsV1", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let metaswapDepositV1 = await getOrNull("MetaSwapDepoistV1")
+  if (metaswapDepositV1) {
+    log(`reusing "MetaSwapUtilsV2" at ${metaswapDepositV1.address}`)
+  } else {
+    metaswapDepositV1 = await deploy("MetaSwapDepositV1", {
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let permissionlessSwapV1 = await getOrNull("PermissionlessSwapV1")
+  if (permissionlessSwapV1) {
+    log(`reusing "PermissionlessSwapV1" at ${permissionlessSwapV1.address}`)
+  } else {
+    permissionlessSwapV1 = await deploy("PermissionlessSwapV1", {
+      contract: "PermissionlessSwap",
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+      args: [(await get("MasterRegistry")).address],
+      libraries: {
+        SwapUtils: swapUtilsV2.address,
+        AmplificationUtils: amplificationUtilsV2.address,
+      },
+    })
+  }
+
+  let permissionlessMetaSwapV1 = await getOrNull("PermissionlessMetaSwapV1")
+  if (permissionlessMetaSwapV1) {
+    log(
+      `reusing "PermissionlessMetaSwapV1" at ${permissionlessMetaSwapV1.address}`,
+    )
+  } else {
+    permissionlessMetaSwapV1 = await deploy("PermissionlessMetaSwapV1", {
+      contract: "PermissionlessMetaSwap",
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+      args: [(await get("MasterRegistry")).address],
+      libraries: {
+        SwapUtils: swapUtilsV2.address,
+        MetaSwapUtils: metaSwapUtilsV1.address,
+        AmplificationUtils: amplificationUtilsV2.address,
+      },
+    })
+  }
+}
+export default func
+func.tags = [
+  "LPTokenV2",
+  "AmplificationUtilsV2",
+  "SwapUtilsV2",
+  "SwapV2",
+  "SwapFlashLoanV1",
+  "PermissionlessMetaSwapV1",
+  "PermissionlessSwapV1",
+  "MetaSwapUtilsV1",
+  "MetaSwapDepositV1",
+]

--- a/deploy/kava_mainnet/201_update_permissionless_deployment_targets.ts
+++ b/deploy/kava_mainnet/201_update_permissionless_deployment_targets.ts
@@ -1,0 +1,96 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { ethers } from "hardhat"
+import { PermissionlessDeployer } from "../../build/typechain"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, log, get } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const permissionlessSwapV1 = await get("PermissionlessSwapV1")
+  const permissionlessMetaSwapV1 = await get("PermissionlessMetaSwapV1")
+  const lpTokenV2 = await get("LPTokenV2")
+  const metaswapDepositV1 = await get("MetaSwapDepositV1")
+
+  const permissionlessDeployer: PermissionlessDeployer =
+    (await ethers.getContract(
+      "PermissionlessDeployer",
+    )) as PermissionlessDeployer
+  if (
+    await permissionlessDeployer.hasRole(
+      await permissionlessDeployer.SADDLE_MANAGER_ROLE(),
+      deployer,
+    )
+  ) {
+    // If LPTokenV2 is not already set as the target LPToken, set it
+    const targetLPToken = await permissionlessDeployer.targetLPToken()
+    if (targetLPToken != lpTokenV2.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetLPToken",
+        lpTokenV2.address,
+      )
+    }
+    // If PermissionlessSwapV1 is not already set as the target Swap, set it
+    const targetSwap = await permissionlessDeployer.targetSwap()
+    if (targetSwap != permissionlessSwapV1.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetSwap",
+        permissionlessSwapV1.address,
+      )
+    }
+    // If PermissionlessMetaSwapV1 is not already set as the target MetaSwap, set it
+    const targetMetaSwap = await permissionlessDeployer.targetMetaSwap()
+    if (targetMetaSwap != permissionlessMetaSwapV1.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetMetaSwap",
+        permissionlessMetaSwapV1.address,
+      )
+    }
+    // If MetaSwapDepoistV1 is not already set as the target MetaSwapDeposit, set it
+    const targetMetaSwapDeposit =
+      await permissionlessDeployer.targetMetaSwapDeposit()
+    if (targetMetaSwapDeposit != metaswapDepositV1.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetMetaSwapDeposit",
+        metaswapDepositV1.address,
+      )
+    }
+  } else {
+    const targetSwap = await permissionlessDeployer.targetSwap()
+    const targetMetaSwap = await permissionlessDeployer.targetMetaSwap()
+    if (
+      targetSwap != permissionlessSwapV1.address ||
+      targetMetaSwap != permissionlessMetaSwapV1.address
+    ) {
+      log(
+        `PermissionlessDeployer targets are out of date, must be updated by manager`,
+      )
+      const manager = await permissionlessDeployer.getRoleMember(
+        await permissionlessDeployer.SADDLE_MANAGER_ROLE(),
+        0,
+      )
+      log(`Currnet manager is ${manager}`)
+    }
+  }
+}
+export default func
+func.dependencies = [
+  "LPTokenV2",
+  "AmplificationUtilsV2",
+  "SwapUtilsV2",
+  "SwapV2",
+  "SwapFlashLoanV1",
+  "PermissionlessMetaSwapV1",
+  "PermissionlessSwapV1",
+  "MetaSwapUtilsV1",
+  "MetaSwapDepoistV1",
+]

--- a/deploy/mainnet/730_deploy_updated_utils.ts
+++ b/deploy/mainnet/730_deploy_updated_utils.ts
@@ -1,0 +1,120 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { deploy, execute, getOrNull, log, get } = deployments
+  const { libraryDeployer, deployer } = await getNamedAccounts()
+
+  let lpTokenV2 = await getOrNull("LPTokenV2")
+  if (lpTokenV2) {
+    log(`reusing "LPToken" at ${lpTokenV2.address}`)
+  } else {
+    lpTokenV2 = await deploy("LPTokenV2", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+
+    await execute(
+      "LPTokenV2",
+      { from: libraryDeployer, log: true },
+      "initialize",
+      "Saddle LP Token (Target)",
+      "saddleLPTokenTarget",
+    )
+  }
+
+  let amplificationUtilsV2 = await getOrNull("AmplificationUtilsV2")
+  if (amplificationUtilsV2) {
+    log(`reusing "AmplificationUtilsV2" at ${amplificationUtilsV2.address}`)
+  } else {
+    amplificationUtilsV2 = await deploy("AmplificationUtilsV2", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let swapUtilsV2 = await getOrNull("SwapUtilsV2")
+  if (swapUtilsV2) {
+    log(`reusing "SwapUtilsV2" at ${swapUtilsV2.address}`)
+  } else {
+    swapUtilsV2 = await deploy("SwapUtilsV2", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let metaSwapUtilsV1 = await getOrNull("MetaSwapUtilsV1")
+  if (metaSwapUtilsV1) {
+    log(`reusing "MetaSwapUtilsV1" at ${metaSwapUtilsV1.address}`)
+  } else {
+    metaSwapUtilsV1 = await deploy("MetaSwapUtilsV1", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let metaswapDepositV1 = await getOrNull("MetaSwapDepoistV1")
+  if (metaswapDepositV1) {
+    log(`reusing "MetaSwapUtilsV2" at ${metaswapDepositV1.address}`)
+  } else {
+    metaswapDepositV1 = await deploy("MetaSwapDepositV1", {
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let permissionlessSwapV1 = await getOrNull("PermissionlessSwapV1")
+  if (permissionlessSwapV1) {
+    log(`reusing "PermissionlessSwapV1" at ${permissionlessSwapV1.address}`)
+  } else {
+    permissionlessSwapV1 = await deploy("PermissionlessSwapV1", {
+      contract: "PermissionlessSwap",
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+      args: [(await get("MasterRegistry")).address],
+      libraries: {
+        SwapUtils: swapUtilsV2.address,
+        AmplificationUtils: amplificationUtilsV2.address,
+      },
+    })
+  }
+
+  let permissionlessMetaSwapV1 = await getOrNull("PermissionlessMetaSwapV1")
+  if (permissionlessMetaSwapV1) {
+    log(
+      `reusing "PermissionlessMetaSwapV1" at ${permissionlessMetaSwapV1.address}`,
+    )
+  } else {
+    permissionlessMetaSwapV1 = await deploy("PermissionlessMetaSwapV1", {
+      contract: "PermissionlessMetaSwap",
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+      args: [(await get("MasterRegistry")).address],
+      libraries: {
+        SwapUtils: swapUtilsV2.address,
+        MetaSwapUtils: metaSwapUtilsV1.address,
+        AmplificationUtils: amplificationUtilsV2.address,
+      },
+    })
+  }
+}
+export default func
+func.tags = [
+  "LPTokenV2",
+  "AmplificationUtilsV2",
+  "SwapUtilsV2",
+  "SwapV2",
+  "SwapFlashLoanV1",
+  "PermissionlessMetaSwapV1",
+  "PermissionlessSwapV1",
+  "MetaSwapUtilsV1",
+  "MetaSwapDepositV1",
+]

--- a/deploy/mainnet/731_update_permissionless_deployment_targets.ts
+++ b/deploy/mainnet/731_update_permissionless_deployment_targets.ts
@@ -1,0 +1,96 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { ethers } from "hardhat"
+import { PermissionlessDeployer } from "../../build/typechain"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, log, get } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const permissionlessSwapV1 = await get("PermissionlessSwapV1")
+  const permissionlessMetaSwapV1 = await get("PermissionlessMetaSwapV1")
+  const lpTokenV2 = await get("LPTokenV2")
+  const metaswapDepositV1 = await get("MetaSwapDepositV1")
+
+  const permissionlessDeployer: PermissionlessDeployer =
+    (await ethers.getContract(
+      "PermissionlessDeployer",
+    )) as PermissionlessDeployer
+  if (
+    await permissionlessDeployer.hasRole(
+      await permissionlessDeployer.SADDLE_MANAGER_ROLE(),
+      deployer,
+    )
+  ) {
+    // If LPTokenV2 is not already set as the target LPToken, set it
+    const targetLPToken = await permissionlessDeployer.targetLPToken()
+    if (targetLPToken != lpTokenV2.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetLPToken",
+        lpTokenV2.address,
+      )
+    }
+    // If PermissionlessSwapV1 is not already set as the target Swap, set it
+    const targetSwap = await permissionlessDeployer.targetSwap()
+    if (targetSwap != permissionlessSwapV1.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetSwap",
+        permissionlessSwapV1.address,
+      )
+    }
+    // If PermissionlessMetaSwapV1 is not already set as the target MetaSwap, set it
+    const targetMetaSwap = await permissionlessDeployer.targetMetaSwap()
+    if (targetMetaSwap != permissionlessMetaSwapV1.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetMetaSwap",
+        permissionlessMetaSwapV1.address,
+      )
+    }
+    // If MetaSwapDepoistV1 is not already set as the target MetaSwapDeposit, set it
+    const targetMetaSwapDeposit =
+      await permissionlessDeployer.targetMetaSwapDeposit()
+    if (targetMetaSwapDeposit != metaswapDepositV1.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetMetaSwapDeposit",
+        metaswapDepositV1.address,
+      )
+    }
+  } else {
+    const targetSwap = await permissionlessDeployer.targetSwap()
+    const targetMetaSwap = await permissionlessDeployer.targetMetaSwap()
+    if (
+      targetSwap != permissionlessSwapV1.address ||
+      targetMetaSwap != permissionlessMetaSwapV1.address
+    ) {
+      log(
+        `PermissionlessDeployer targets are out of date, must be updated by multisig`,
+      )
+      const manager = await permissionlessDeployer.getRoleMember(
+        await permissionlessDeployer.SADDLE_MANAGER_ROLE(),
+        0,
+      )
+      log(`Currnet manager is ${manager}`)
+    }
+  }
+}
+export default func
+func.dependencies = [
+  "LPTokenV2",
+  "AmplificationUtilsV2",
+  "SwapUtilsV2",
+  "SwapV2",
+  "SwapFlashLoanV1",
+  "PermissionlessMetaSwapV1",
+  "PermissionlessSwapV1",
+  "MetaSwapUtilsV1",
+  "MetaSwapDepoistV1",
+]

--- a/deploy/optimism/250_update_childGauges_manager.ts
+++ b/deploy/optimism/250_update_childGauges_manager.ts
@@ -1,0 +1,35 @@
+import { ethers } from "hardhat"
+import { DeployFunction } from "hardhat-deploy/types"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { ChildGauge } from "../../build/typechain"
+import { OPS_MULTISIG_ADDRESSES } from "../../utils/accounts"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, getChainId } = hre
+  const { execute } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const allDeploys = await deployments.all()
+  for (const contractName in allDeploys) {
+    if (
+      contractName.startsWith("ChildGauge") &&
+      contractName.includes("LPToken")
+    ) {
+      const childGaugeContract: ChildGauge = (await ethers.getContract(
+        contractName,
+      )) as ChildGauge
+      if (
+        (await childGaugeContract.manager()) !=
+        OPS_MULTISIG_ADDRESSES[await getChainId()]
+      ) {
+        await execute(
+          contractName,
+          { from: deployer, log: true },
+          "set_manager",
+          OPS_MULTISIG_ADDRESSES[await getChainId()],
+        )
+      }
+    }
+  }
+}
+export default func

--- a/deploy/optimism/251_deploy_updated_utils.ts
+++ b/deploy/optimism/251_deploy_updated_utils.ts
@@ -1,0 +1,120 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { deploy, execute, getOrNull, log, get } = deployments
+  const { libraryDeployer, deployer } = await getNamedAccounts()
+
+  let lpTokenV2 = await getOrNull("LPTokenV2")
+  if (lpTokenV2) {
+    log(`reusing "LPToken" at ${lpTokenV2.address}`)
+  } else {
+    lpTokenV2 = await deploy("LPTokenV2", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+
+    await execute(
+      "LPTokenV2",
+      { from: libraryDeployer, log: true },
+      "initialize",
+      "Saddle LP Token (Target)",
+      "saddleLPTokenTarget",
+    )
+  }
+
+  let amplificationUtilsV2 = await getOrNull("AmplificationUtilsV2")
+  if (amplificationUtilsV2) {
+    log(`reusing "AmplificationUtilsV2" at ${amplificationUtilsV2.address}`)
+  } else {
+    amplificationUtilsV2 = await deploy("AmplificationUtilsV2", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let swapUtilsV2 = await getOrNull("SwapUtilsV2")
+  if (swapUtilsV2) {
+    log(`reusing "SwapUtilsV2" at ${swapUtilsV2.address}`)
+  } else {
+    swapUtilsV2 = await deploy("SwapUtilsV2", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let metaSwapUtilsV1 = await getOrNull("MetaSwapUtilsV1")
+  if (metaSwapUtilsV1) {
+    log(`reusing "MetaSwapUtilsV1" at ${metaSwapUtilsV1.address}`)
+  } else {
+    metaSwapUtilsV1 = await deploy("MetaSwapUtilsV1", {
+      from: libraryDeployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let metaswapDepositV1 = await getOrNull("MetaSwapDepoistV1")
+  if (metaswapDepositV1) {
+    log(`reusing "MetaSwapUtilsV2" at ${metaswapDepositV1.address}`)
+  } else {
+    metaswapDepositV1 = await deploy("MetaSwapDepositV1", {
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+    })
+  }
+
+  let permissionlessSwapV1 = await getOrNull("PermissionlessSwapV1")
+  if (permissionlessSwapV1) {
+    log(`reusing "PermissionlessSwapV1" at ${permissionlessSwapV1.address}`)
+  } else {
+    permissionlessSwapV1 = await deploy("PermissionlessSwapV1", {
+      contract: "PermissionlessSwap",
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+      args: [(await get("MasterRegistry")).address],
+      libraries: {
+        SwapUtils: swapUtilsV2.address,
+        AmplificationUtils: amplificationUtilsV2.address,
+      },
+    })
+  }
+
+  let permissionlessMetaSwapV1 = await getOrNull("PermissionlessMetaSwapV1")
+  if (permissionlessMetaSwapV1) {
+    log(
+      `reusing "PermissionlessMetaSwapV1" at ${permissionlessMetaSwapV1.address}`,
+    )
+  } else {
+    permissionlessMetaSwapV1 = await deploy("PermissionlessMetaSwapV1", {
+      contract: "PermissionlessMetaSwap",
+      from: deployer,
+      log: true,
+      skipIfAlreadyDeployed: true,
+      args: [(await get("MasterRegistry")).address],
+      libraries: {
+        SwapUtils: swapUtilsV2.address,
+        MetaSwapUtils: metaSwapUtilsV1.address,
+        AmplificationUtils: amplificationUtilsV2.address,
+      },
+    })
+  }
+}
+export default func
+func.tags = [
+  "LPTokenV2",
+  "AmplificationUtilsV2",
+  "SwapUtilsV2",
+  "SwapV2",
+  "SwapFlashLoanV1",
+  "PermissionlessMetaSwapV1",
+  "PermissionlessSwapV1",
+  "MetaSwapUtilsV1",
+  "MetaSwapDepositV1",
+]

--- a/deploy/optimism/252_update_permissionless_deployment_targets.ts
+++ b/deploy/optimism/252_update_permissionless_deployment_targets.ts
@@ -1,0 +1,96 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { ethers } from "hardhat"
+import { PermissionlessDeployer } from "../../build/typechain"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { execute, log, get } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const permissionlessSwapV1 = await get("PermissionlessSwapV1")
+  const permissionlessMetaSwapV1 = await get("PermissionlessMetaSwapV1")
+  const lpTokenV2 = await get("LPTokenV2")
+  const metaswapDepositV1 = await get("MetaSwapDepositV1")
+
+  const permissionlessDeployer: PermissionlessDeployer =
+    (await ethers.getContract(
+      "PermissionlessDeployer",
+    )) as PermissionlessDeployer
+  if (
+    await permissionlessDeployer.hasRole(
+      await permissionlessDeployer.SADDLE_MANAGER_ROLE(),
+      deployer,
+    )
+  ) {
+    // If LPTokenV2 is not already set as the target LPToken, set it
+    const targetLPToken = await permissionlessDeployer.targetLPToken()
+    if (targetLPToken != lpTokenV2.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetLPToken",
+        lpTokenV2.address,
+      )
+    }
+    // If PermissionlessSwapV1 is not already set as the target Swap, set it
+    const targetSwap = await permissionlessDeployer.targetSwap()
+    if (targetSwap != permissionlessSwapV1.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetSwap",
+        permissionlessSwapV1.address,
+      )
+    }
+    // If PermissionlessMetaSwapV1 is not already set as the target MetaSwap, set it
+    const targetMetaSwap = await permissionlessDeployer.targetMetaSwap()
+    if (targetMetaSwap != permissionlessMetaSwapV1.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetMetaSwap",
+        permissionlessMetaSwapV1.address,
+      )
+    }
+    // If MetaSwapDepoistV1 is not already set as the target MetaSwapDeposit, set it
+    const targetMetaSwapDeposit =
+      await permissionlessDeployer.targetMetaSwapDeposit()
+    if (targetMetaSwapDeposit != metaswapDepositV1.address) {
+      await execute(
+        "PermissionlessDeployer",
+        { from: deployer, log: true },
+        "setTargetMetaSwapDeposit",
+        metaswapDepositV1.address,
+      )
+    }
+  } else {
+    const targetSwap = await permissionlessDeployer.targetSwap()
+    const targetMetaSwap = await permissionlessDeployer.targetMetaSwap()
+    if (
+      targetSwap != permissionlessSwapV1.address ||
+      targetMetaSwap != permissionlessMetaSwapV1.address
+    ) {
+      log(
+        `PermissionlessDeployer targets are out of date, must be updated by multisig`,
+      )
+      const manager = await permissionlessDeployer.getRoleMember(
+        await permissionlessDeployer.SADDLE_MANAGER_ROLE(),
+        0,
+      )
+      log(`Currnet manager is ${manager}`)
+    }
+  }
+}
+export default func
+func.dependencies = [
+  "LPTokenV2",
+  "AmplificationUtilsV2",
+  "SwapUtilsV2",
+  "SwapV2",
+  "SwapFlashLoanV1",
+  "PermissionlessMetaSwapV1",
+  "PermissionlessSwapV1",
+  "MetaSwapUtilsV1",
+  "MetaSwapDepoistV1",
+]


### PR DESCRIPTION
- Deploys updated versions of AmplificationUtils, MetaSwapUtils, SwapUtils on all chains.
- Updates manager role for all child gauges to be the OPS Multisig.
- Deploys updated version of Permissionless Swap/MetaSwap, Updates PermissionlessDeployer targets if possible (only actually possible on kava_mainnet, all other networks require an ops multisig-tx)